### PR TITLE
Add CI workflow that runs type-check and bundle on every PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: node esbuild.js --production


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build.yml` running `npm ci`, `npx tsc --noEmit`, and `node esbuild.js --production` on pull requests targeting `main` and pushes to `main`.
- Ubuntu latest, Node 20.x, with `actions/setup-node`'s built-in npm cache. No test step — `@vscode/test-electron` needs xvfb and is out of scope per the issue.

## Verification

- [x] This PR's own CI run passed — [run 24806111993](https://github.com/dvlprlife/Markdown-Forge/actions/runs/24806111993) (build job green, 15s). Confirms the workflow fires on a PR targeting `main` and exits clean on code that type-checks.
- [x] Throwaway PR #11 with a deliberate type error failed the workflow — [run 24806144523](https://github.com/dvlprlife/Markdown-Forge/actions/runs/24806144523) (build job red, 14s). Confirms `npx tsc --noEmit` non-zero exit fails the job as expected. Throwaway PR and branch closed/deleted before merge.

Closes #3