### PR TITLE
Ignore .claude/ directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ dist/
 out/
 *.vsix
 .vscode-test/
+.claude/
 .DS_Store
 CONTEXT.md
-.claude


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore`, grouped with the other editor/tool entries (between `.vscode-test/` and `.DS_Store`) with the trailing-slash directory style.
- **Deviation from the plan:** the working tree already contained a bare `.claude` line at the end of `.gitignore` (added out of band between plan and implementation). This PR removes that line so the final state matches the plan exactly — functionally equivalent since either pattern ignores the directory, but keeping both would be redundant.

## Verification

- [x] `git diff .gitignore` shows `+.claude/` between `.vscode-test/` and `.DS_Store`, and `-.claude` at file end — no other changes
- [x] `git status` confirms the local `.claude/` directory is no longer untracked
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [x] Only `.gitignore` modified; no other files touched

Closes #12