### PR TITLE
Ignore GETTING_STARTED.md in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out/
 .claude/
 .DS_Store
 CONTEXT.md
+GETTING_STARTED.md


### PR DESCRIPTION
## Summary

- Adds `GETTING_STARTED.md` to `.gitignore`, grouped with the other local-only doc entries at the end of the file (alongside `CONTEXT.md`).
- No other changes.

## Verification

- [x] `git diff .gitignore` shows exactly one added line: `+GETTING_STARTED.md` — no other lines moved or changed
- [x] `git status` no longer lists `GETTING_STARTED.md` as untracked; working copy preserved
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [x] Only `.gitignore` modified; no other files touched

Closes #15