### PR TITLE
Update README to reflect current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Markdown Forge makes working with tables fast and ergonomic — align columns, n
 ### Insertion commands
 
 - **Paste Link** — If the clipboard contains a URL, wrap the selection (or prompt for text) and insert `[text](url)`.
-- **Paste Image** — Save the clipboard image to a configurable folder and insert a Markdown image reference.
+- **Paste Image** — Save the clipboard image to a configurable folder and insert a Markdown image reference. *Windows only in v0.x; macOS and Linux support is tracked in [#4](https://github.com/dvlprlife/Markdown-Forge/issues/4) and [#5](https://github.com/dvlprlife/Markdown-Forge/issues/5).*
 
 ## Keybindings
 
@@ -48,7 +48,7 @@ All other commands are available through the Command Palette (search for "Markdo
 
 ## Issues and feedback
 
-Please file issues and feature requests on [GitHub](https://github.com/your-username/markdown-forge).
+Please file issues and feature requests on [GitHub](https://github.com/dvlprlife/Markdown-Forge).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds a "Windows only in v0.x" note to the **Paste Image** bullet with links to the macOS/Linux tracking issues (#4 and #5).
- Replaces the placeholder `your-username/markdown-forge` URL in the "Issues and feedback" section with the real repo URL.

## Verification

- [x] `git diff README.md` shows exactly 2 lines changed (1 per targeted edit); no surrounding lines touched
- [x] `git status` shows only `M README.md`
- [x] `npx tsc --noEmit` passes (exit 0 — README isn't on the type-check path but ran per CLAUDE.md gate)
- [x] `node esbuild.js --production` passes (exit 0)
- [x] Markdown preview of the updated README in VS Code renders the new italic note with two working issue links and the corrected Issues link

Closes #20