### PR TITLE
Set publisher ID in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Markdown Forge",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
   "version": "0.1.0",
-  "publisher": "your-publisher-id",
+  "publisher": "dvlprlife",
   "license": "MIT",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## Summary

- Sets `publisher` in `package.json` to `dvlprlife` (registered marketplace publisher ID), replacing the placeholder `your-publisher-id`.
- Last blocking pre-publish metadata change before `vsce publish` will accept the extension.

## Verification

- [x] `git diff package.json` shows exactly one line changed (line 6)
- [x] `node -e "JSON.parse(...)"` confirms `package.json` is still valid JSON
- [x] No other fields modified (version, displayName, description, commands, keybindings, settings all unchanged)
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)

Closes #22