### PR TITLE
Fix .vscodeignore to exclude private/internal files from marketplace package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,9 @@ vsc-extension-quickstart.md
 **/.vscode-test/**
 node_modules/**
 .github/**
+CLAUDE.md
+CONTEXT.md
+GETTING_STARTED.md
+agents/**
+.claude/**
+.vscode-test.mjs


### PR DESCRIPTION
## Summary

- Adds 6 exclusion lines to `.vscodeignore` so `vsce` no longer bundles `CLAUDE.md`, `CONTEXT.md`, `GETTING_STARTED.md`, `agents/**`, `.claude/**`, or `.vscode-test.mjs`.
- **Blocker for v0.1.0 publish** — without this, private planning notes and Claude Code session state would be uploaded to the marketplace.

## Verification

- [x] `git diff .vscodeignore` shows 6 lines appended, no other modifications
- [x] `git status --short` shows only `M .vscodeignore`
- [x] `vsce ls` output contains exactly the 9 expected user-facing files: `README.md`, `package.json`, `LICENSE`, `CHANGELOG.md`, `dist/extension.js`, `images/icon.png`, `images/demo/align.gif`, `images/demo/maketable.gif`, `images/demo/sort.gif`
- [x] `vsce ls` does NOT contain any of: `CLAUDE.md`, `CONTEXT.md`, `GETTING_STARTED.md`, any `agents/*`, any `.claude/*`, `.vscode-test.mjs`
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)

Closes #26