### PR TITLE
Rename extension name to mdforge (publish blocker)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "markdown-forge",
+  "name": "mdforge",
   "displayName": "Markdown Forge",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
   "version": "0.1.0",


### PR DESCRIPTION
## Summary

- Renames the `package.json` `name` field from `markdown-forge` to `mdforge`. Extension ID becomes `dvlprlife.mdforge`.
- `displayName: "Markdown Forge"` unchanged — user-facing brand, icon, README, and CLAUDE.md all still read "Markdown Forge".
- **Unblocks v0.1.0 publish** — `markdown-forge` is taken globally in the marketplace.

## Verification

- [x] `git diff package.json` shows exactly one line changed (line 2)
- [x] JSON still parses (`node -e "JSON.parse(...)"` exits 0)
- [x] `displayName`, `version`, `publisher`, `description`, `repository`, `engines`, and all `contributes.*` entries unchanged
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [x] Command IDs (`markdownForge.*`) and configuration keys in source unchanged — those use the namespace prefix, not the extension `name`

Closes #28