### PR TITLE
Rename extension displayName to Markdown Foundry (publish blocker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the Markdown Forge extension will be documented in this file.
+All notable changes to the Markdown Foundry extension will be documented in this file.
 
 ## [0.1.0] - Unreleased
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Markdown Forge contributors
+Copyright (c) 2026 Markdown Foundry contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Markdown Forge
+# Markdown Foundry
 
 Powerful Markdown table editing and authoring tools for Visual Studio Code.
 
-Markdown Forge makes working with tables fast and ergonomic — align columns, navigate between cells with Tab, insert and reorder rows and columns, sort data, and paste links or images with a keystroke.
+Markdown Foundry makes working with tables fast and ergonomic — align columns, navigate between cells with Tab, insert and reorder rows and columns, sort data, and paste links or images with a keystroke.
 
 ## Demo
 
@@ -39,7 +39,7 @@ Markdown Forge makes working with tables fast and ergonomic — align columns, n
 | `Ctrl+Shift+T` / `Cmd+Shift+T` | Align table |
 | `Ctrl+Alt+V` / `Cmd+Alt+V` | Paste image |
 
-All other commands are available through the Command Palette (search for "Markdown Forge").
+All other commands are available through the Command Palette (search for "Markdown Foundry").
 
 ## Settings
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdforge",
-  "displayName": "Markdown Forge",
+  "displayName": "Markdown Foundry",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
   "version": "0.1.0",
   "publisher": "dvlprlife",
@@ -31,24 +31,24 @@
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
-      { "command": "markdownForge.alignTable",              "title": "Markdown Forge: Align Table",               "category": "Markdown Forge" },
-      { "command": "markdownForge.insertRowAbove",          "title": "Markdown Forge: Insert Row Above",          "category": "Markdown Forge" },
-      { "command": "markdownForge.insertRowBelow",          "title": "Markdown Forge: Insert Row Below",          "category": "Markdown Forge" },
-      { "command": "markdownForge.insertColumnLeft",        "title": "Markdown Forge: Insert Column Left",        "category": "Markdown Forge" },
-      { "command": "markdownForge.insertColumnRight",       "title": "Markdown Forge: Insert Column Right",       "category": "Markdown Forge" },
-      { "command": "markdownForge.deleteRow",               "title": "Markdown Forge: Delete Row",                "category": "Markdown Forge" },
-      { "command": "markdownForge.deleteColumn",            "title": "Markdown Forge: Delete Column",             "category": "Markdown Forge" },
-      { "command": "markdownForge.moveRowUp",               "title": "Markdown Forge: Move Row Up",               "category": "Markdown Forge" },
-      { "command": "markdownForge.moveRowDown",             "title": "Markdown Forge: Move Row Down",             "category": "Markdown Forge" },
-      { "command": "markdownForge.moveColumnLeft",          "title": "Markdown Forge: Move Column Left",          "category": "Markdown Forge" },
-      { "command": "markdownForge.moveColumnRight",         "title": "Markdown Forge: Move Column Right",         "category": "Markdown Forge" },
-      { "command": "markdownForge.sortByColumn",            "title": "Markdown Forge: Sort Table by Column",      "category": "Markdown Forge" },
-      { "command": "markdownForge.convertSelectionToTable", "title": "Markdown Forge: Convert Selection to Table","category": "Markdown Forge" },
-      { "command": "markdownForge.nextCell",                "title": "Markdown Forge: Next Cell",                 "category": "Markdown Forge" },
-      { "command": "markdownForge.previousCell",            "title": "Markdown Forge: Previous Cell",             "category": "Markdown Forge" },
-      { "command": "markdownForge.nextRow",                 "title": "Markdown Forge: Next Row",                  "category": "Markdown Forge" },
-      { "command": "markdownForge.pasteLink",               "title": "Markdown Forge: Paste Link",                "category": "Markdown Forge" },
-      { "command": "markdownForge.pasteImage",              "title": "Markdown Forge: Paste Image",               "category": "Markdown Forge" }
+      { "command": "markdownForge.alignTable",              "title": "Markdown Foundry: Align Table",               "category": "Markdown Foundry" },
+      { "command": "markdownForge.insertRowAbove",          "title": "Markdown Foundry: Insert Row Above",          "category": "Markdown Foundry" },
+      { "command": "markdownForge.insertRowBelow",          "title": "Markdown Foundry: Insert Row Below",          "category": "Markdown Foundry" },
+      { "command": "markdownForge.insertColumnLeft",        "title": "Markdown Foundry: Insert Column Left",        "category": "Markdown Foundry" },
+      { "command": "markdownForge.insertColumnRight",       "title": "Markdown Foundry: Insert Column Right",       "category": "Markdown Foundry" },
+      { "command": "markdownForge.deleteRow",               "title": "Markdown Foundry: Delete Row",                "category": "Markdown Foundry" },
+      { "command": "markdownForge.deleteColumn",            "title": "Markdown Foundry: Delete Column",             "category": "Markdown Foundry" },
+      { "command": "markdownForge.moveRowUp",               "title": "Markdown Foundry: Move Row Up",               "category": "Markdown Foundry" },
+      { "command": "markdownForge.moveRowDown",             "title": "Markdown Foundry: Move Row Down",             "category": "Markdown Foundry" },
+      { "command": "markdownForge.moveColumnLeft",          "title": "Markdown Foundry: Move Column Left",          "category": "Markdown Foundry" },
+      { "command": "markdownForge.moveColumnRight",         "title": "Markdown Foundry: Move Column Right",         "category": "Markdown Foundry" },
+      { "command": "markdownForge.sortByColumn",            "title": "Markdown Foundry: Sort Table by Column",      "category": "Markdown Foundry" },
+      { "command": "markdownForge.convertSelectionToTable", "title": "Markdown Foundry: Convert Selection to Table","category": "Markdown Foundry" },
+      { "command": "markdownForge.nextCell",                "title": "Markdown Foundry: Next Cell",                 "category": "Markdown Foundry" },
+      { "command": "markdownForge.previousCell",            "title": "Markdown Foundry: Previous Cell",             "category": "Markdown Foundry" },
+      { "command": "markdownForge.nextRow",                 "title": "Markdown Foundry: Next Row",                  "category": "Markdown Foundry" },
+      { "command": "markdownForge.pasteLink",               "title": "Markdown Foundry: Paste Link",                "category": "Markdown Foundry" },
+      { "command": "markdownForge.pasteImage",              "title": "Markdown Foundry: Paste Image",               "category": "Markdown Foundry" }
     ],
     "keybindings": [
       {
@@ -80,7 +80,7 @@
       }
     ],
     "configuration": {
-      "title": "Markdown Forge",
+      "title": "Markdown Foundry",
       "properties": {
         "markdownForge.alignOnSave": {
           "type": "boolean",

--- a/src/insert/image.ts
+++ b/src/insert/image.ts
@@ -14,7 +14,7 @@ export async function pasteImageCommand(): Promise<void> {
 
   const document = editor.document;
   if (document.uri.scheme !== 'file') {
-    vscode.window.showInformationMessage('Markdown Forge: image paste requires a saved file.');
+    vscode.window.showInformationMessage('Markdown Foundry: image paste requires a saved file.');
     return;
   }
 
@@ -33,7 +33,7 @@ export async function pasteImageCommand(): Promise<void> {
     await saveClipboardImage(targetPath);
   } catch (err) {
     vscode.window.showErrorMessage(
-      `Markdown Forge: could not paste image. ${err instanceof Error ? err.message : String(err)}`
+      `Markdown Foundry: could not paste image. ${err instanceof Error ? err.message : String(err)}`
     );
     return;
   }

--- a/src/insert/link.ts
+++ b/src/insert/link.ts
@@ -17,7 +17,7 @@ export async function pasteLinkCommand(): Promise<void> {
 
   const clipboard = (await vscode.env.clipboard.readText()).trim();
   if (!URL_RE.test(clipboard)) {
-    vscode.window.showInformationMessage('Markdown Forge: clipboard does not contain a URL.');
+    vscode.window.showInformationMessage('Markdown Foundry: clipboard does not contain a URL.');
     return;
   }
 

--- a/src/table/commands/align.ts
+++ b/src/table/commands/align.ts
@@ -23,7 +23,7 @@ export async function alignTableCommand(): Promise<void> {
 
   const location = locateTable(document, cursorLine);
   if (!location) {
-    vscode.window.showInformationMessage('Markdown Forge: cursor is not inside a table.');
+    vscode.window.showInformationMessage('Markdown Foundry: cursor is not inside a table.');
     return;
   }
 

--- a/src/table/commands/convert.ts
+++ b/src/table/commands/convert.ts
@@ -19,7 +19,7 @@ export async function convertSelectionToTableCommand(): Promise<void> {
 
   const selection = editor.selection;
   if (selection.isEmpty) {
-    vscode.window.showInformationMessage('Markdown Forge: select CSV or TSV text to convert.');
+    vscode.window.showInformationMessage('Markdown Foundry: select CSV or TSV text to convert.');
     return;
   }
 

--- a/src/table/commands/rowColumn.ts
+++ b/src/table/commands/rowColumn.ts
@@ -18,13 +18,13 @@ async function transformTable(
   const cursorLine = editor.selection.active.line;
   const location = locateTable(document, cursorLine);
   if (!location) {
-    vscode.window.showInformationMessage('Markdown Forge: cursor is not inside a table.');
+    vscode.window.showInformationMessage('Markdown Foundry: cursor is not inside a table.');
     return;
   }
 
   const coords = cursorToTableCoords(document, location, editor.selection.active);
   if (!coords) {
-    vscode.window.showInformationMessage('Markdown Forge: cursor is on the separator row.');
+    vscode.window.showInformationMessage('Markdown Foundry: cursor is on the separator row.');
     return;
   }
 
@@ -93,7 +93,7 @@ function insertColumnAt(model: TableModel, index: number): TableModel {
 export async function deleteRowCommand(): Promise<void> {
   await transformTable((model, { rowIndex }) => {
     if (rowIndex < 0) {
-      vscode.window.showInformationMessage('Markdown Forge: cannot delete the header row.');
+      vscode.window.showInformationMessage('Markdown Foundry: cannot delete the header row.');
       return null;
     }
     if (model.rows.length === 0) return null;
@@ -106,7 +106,7 @@ export async function deleteRowCommand(): Promise<void> {
 export async function deleteColumnCommand(): Promise<void> {
   await transformTable((model, { columnIndex }) => {
     if (model.headers.length <= 1) {
-      vscode.window.showInformationMessage('Markdown Forge: cannot delete the last column.');
+      vscode.window.showInformationMessage('Markdown Foundry: cannot delete the last column.');
       return null;
     }
     const headers = [...model.headers];

--- a/src/table/commands/sort.ts
+++ b/src/table/commands/sort.ts
@@ -16,7 +16,7 @@ export async function sortByColumnCommand(): Promise<void> {
   const cursorLine = editor.selection.active.line;
   const location = locateTable(document, cursorLine);
   if (!location) {
-    vscode.window.showInformationMessage('Markdown Forge: cursor is not inside a table.');
+    vscode.window.showInformationMessage('Markdown Foundry: cursor is not inside a table.');
     return;
   }
 


### PR DESCRIPTION
## Summary

- Rebrands the user-facing name from "Markdown Forge" to "Markdown Foundry" across `package.json` displayName + command titles + categories + config section, `README.md`, `CHANGELOG.md`, `LICENSE`, and 10 popup messages in `src/**/*.ts`.
- 36 literal replacements across 10 files; no semantic changes.
- **Unblocks v0.1.0 publish** — `vsce publish` was rejected with "This extension display name is taken".

## Verification

- [x] `git diff --stat` shows exactly 10 files modified, 35 insertions / 35 deletions (pure replacements)
- [x] `Grep` for `Markdown Forge` against tracked files returns zero matches
- [x] `package.json` `displayName` = `"Markdown Foundry"`; 18 command titles prefixed `"Markdown Foundry: <X>"`; 18 categories = `"Markdown Foundry"`; config section `title` = `"Markdown Foundry"`
- [x] `package.json` `name` still `"mdforge"` (unchanged)
- [x] All `markdownForge.*` command IDs, configuration keys, and context key unchanged in both manifest and source
- [x] `agents/**`, `CLAUDE.md`, icon unchanged
- [x] `node -e "JSON.parse(...)"` confirms `package.json` still parses
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)

Closes #30