### PR TITLE
Rename command and configuration namespace from markdownForge to markdownFoundry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 ### Added
 
 - Align table command (`Ctrl+Shift+T` / `Cmd+Shift+T`)
-- Align all tables in document on save (opt-in via `markdownForge.alignOnSave`)
+- Align all tables in document on save (opt-in via `markdownFoundry.alignOnSave`)
 - Insert/delete/move row and column commands
 - Sort table by column (ascending/descending, numeric detection)
 - Convert CSV/TSV selection to Markdown table

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ These are non-negotiable:
 - **Layer discipline.** `locator` / `parser` / `formatter` are pure (no `vscode` imports beyond types). Only files in `src/table/commands/` and `src/insert/` touch the editor.
 - **Forward slashes in inserted Markdown.** When writing a path into the document, normalize with `path.relative(...).split(path.sep).join('/')`. Markdown rendered on non-Windows must work.
 - **Stubs fail loudly.** A not-yet-implemented platform handler must throw with a clear message (e.g. `"saveClipboardImage: Linux/Wayland not yet supported"`), never silently no-op or return a fake success.
-- **Tab/Shift-Tab/Enter gating.** Keybindings must include `markdownForge.inTable && !editorHasSelection && !suggestWidgetVisible` so default editor behavior is preserved outside tables and the suggest widget is not hijacked.
+- **Tab/Shift-Tab/Enter gating.** Keybindings must include `markdownFoundry.inTable && !editorHasSelection && !suggestWidgetVisible` so default editor behavior is preserved outside tables and the suggest widget is not hijacked.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ All other commands are available through the Command Palette (search for "Markdo
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| `markdownForge.alignOnSave` | `false` | Align all tables in the file when saving. |
-| `markdownForge.defaultAlignment` | `"left"` | Alignment for new columns. |
-| `markdownForge.imageFolder` | `"images"` | Folder (relative to the file) where pasted images are saved. |
-| `markdownForge.imageNameFormat` | `"image-${timestamp}"` | Template for pasted image filenames. Tokens: `${timestamp}`, `${date}`, `${filename}`. |
+| `markdownFoundry.alignOnSave` | `false` | Align all tables in the file when saving. |
+| `markdownFoundry.defaultAlignment` | `"left"` | Alignment for new columns. |
+| `markdownFoundry.imageFolder` | `"images"` | Folder (relative to the file) where pasted images are saved. |
+| `markdownFoundry.imageNameFormat` | `"image-${timestamp}"` | Template for pasted image filenames. Tokens: `${timestamp}`, `${date}`, `${filename}`. |
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -31,49 +31,49 @@
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
-      { "command": "markdownForge.alignTable",              "title": "Markdown Foundry: Align Table",               "category": "Markdown Foundry" },
-      { "command": "markdownForge.insertRowAbove",          "title": "Markdown Foundry: Insert Row Above",          "category": "Markdown Foundry" },
-      { "command": "markdownForge.insertRowBelow",          "title": "Markdown Foundry: Insert Row Below",          "category": "Markdown Foundry" },
-      { "command": "markdownForge.insertColumnLeft",        "title": "Markdown Foundry: Insert Column Left",        "category": "Markdown Foundry" },
-      { "command": "markdownForge.insertColumnRight",       "title": "Markdown Foundry: Insert Column Right",       "category": "Markdown Foundry" },
-      { "command": "markdownForge.deleteRow",               "title": "Markdown Foundry: Delete Row",                "category": "Markdown Foundry" },
-      { "command": "markdownForge.deleteColumn",            "title": "Markdown Foundry: Delete Column",             "category": "Markdown Foundry" },
-      { "command": "markdownForge.moveRowUp",               "title": "Markdown Foundry: Move Row Up",               "category": "Markdown Foundry" },
-      { "command": "markdownForge.moveRowDown",             "title": "Markdown Foundry: Move Row Down",             "category": "Markdown Foundry" },
-      { "command": "markdownForge.moveColumnLeft",          "title": "Markdown Foundry: Move Column Left",          "category": "Markdown Foundry" },
-      { "command": "markdownForge.moveColumnRight",         "title": "Markdown Foundry: Move Column Right",         "category": "Markdown Foundry" },
-      { "command": "markdownForge.sortByColumn",            "title": "Markdown Foundry: Sort Table by Column",      "category": "Markdown Foundry" },
-      { "command": "markdownForge.convertSelectionToTable", "title": "Markdown Foundry: Convert Selection to Table","category": "Markdown Foundry" },
-      { "command": "markdownForge.nextCell",                "title": "Markdown Foundry: Next Cell",                 "category": "Markdown Foundry" },
-      { "command": "markdownForge.previousCell",            "title": "Markdown Foundry: Previous Cell",             "category": "Markdown Foundry" },
-      { "command": "markdownForge.nextRow",                 "title": "Markdown Foundry: Next Row",                  "category": "Markdown Foundry" },
-      { "command": "markdownForge.pasteLink",               "title": "Markdown Foundry: Paste Link",                "category": "Markdown Foundry" },
-      { "command": "markdownForge.pasteImage",              "title": "Markdown Foundry: Paste Image",               "category": "Markdown Foundry" }
+      { "command": "markdownFoundry.alignTable",              "title": "Markdown Foundry: Align Table",               "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.insertRowAbove",          "title": "Markdown Foundry: Insert Row Above",          "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.insertRowBelow",          "title": "Markdown Foundry: Insert Row Below",          "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.insertColumnLeft",        "title": "Markdown Foundry: Insert Column Left",        "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.insertColumnRight",       "title": "Markdown Foundry: Insert Column Right",       "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.deleteRow",               "title": "Markdown Foundry: Delete Row",                "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.deleteColumn",            "title": "Markdown Foundry: Delete Column",             "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.moveRowUp",               "title": "Markdown Foundry: Move Row Up",               "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.moveRowDown",             "title": "Markdown Foundry: Move Row Down",             "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.moveColumnLeft",          "title": "Markdown Foundry: Move Column Left",          "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.moveColumnRight",         "title": "Markdown Foundry: Move Column Right",         "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.sortByColumn",            "title": "Markdown Foundry: Sort Table by Column",      "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.convertSelectionToTable", "title": "Markdown Foundry: Convert Selection to Table","category": "Markdown Foundry" },
+      { "command": "markdownFoundry.nextCell",                "title": "Markdown Foundry: Next Cell",                 "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.previousCell",            "title": "Markdown Foundry: Previous Cell",             "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.nextRow",                 "title": "Markdown Foundry: Next Row",                  "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.pasteLink",               "title": "Markdown Foundry: Paste Link",                "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.pasteImage",              "title": "Markdown Foundry: Paste Image",               "category": "Markdown Foundry" }
     ],
     "keybindings": [
       {
-        "command": "markdownForge.nextCell",
+        "command": "markdownFoundry.nextCell",
         "key": "tab",
-        "when": "editorTextFocus && editorLangId == markdown && markdownForge.inTable && !editorHasSelection && !suggestWidgetVisible"
+        "when": "editorTextFocus && editorLangId == markdown && markdownFoundry.inTable && !editorHasSelection && !suggestWidgetVisible"
       },
       {
-        "command": "markdownForge.previousCell",
+        "command": "markdownFoundry.previousCell",
         "key": "shift+tab",
-        "when": "editorTextFocus && editorLangId == markdown && markdownForge.inTable && !editorHasSelection && !suggestWidgetVisible"
+        "when": "editorTextFocus && editorLangId == markdown && markdownFoundry.inTable && !editorHasSelection && !suggestWidgetVisible"
       },
       {
-        "command": "markdownForge.nextRow",
+        "command": "markdownFoundry.nextRow",
         "key": "enter",
-        "when": "editorTextFocus && editorLangId == markdown && markdownForge.inTable && !editorHasSelection && !suggestWidgetVisible"
+        "when": "editorTextFocus && editorLangId == markdown && markdownFoundry.inTable && !editorHasSelection && !suggestWidgetVisible"
       },
       {
-        "command": "markdownForge.alignTable",
+        "command": "markdownFoundry.alignTable",
         "key": "ctrl+shift+t",
         "mac": "cmd+shift+t",
         "when": "editorTextFocus && editorLangId == markdown"
       },
       {
-        "command": "markdownForge.pasteImage",
+        "command": "markdownFoundry.pasteImage",
         "key": "ctrl+alt+v",
         "mac": "cmd+alt+v",
         "when": "editorTextFocus && editorLangId == markdown"
@@ -82,23 +82,23 @@
     "configuration": {
       "title": "Markdown Foundry",
       "properties": {
-        "markdownForge.alignOnSave": {
+        "markdownFoundry.alignOnSave": {
           "type": "boolean",
           "default": false,
           "description": "Automatically align all Markdown tables in the file when it is saved."
         },
-        "markdownForge.defaultAlignment": {
+        "markdownFoundry.defaultAlignment": {
           "type": "string",
           "enum": ["left", "center", "right"],
           "default": "left",
           "description": "Default column alignment for new tables and newly inserted columns."
         },
-        "markdownForge.imageFolder": {
+        "markdownFoundry.imageFolder": {
           "type": "string",
           "default": "images",
           "description": "Folder (relative to the current file) where pasted images are saved."
         },
-        "markdownForge.imageNameFormat": {
+        "markdownFoundry.imageNameFormat": {
           "type": "string",
           "default": "image-${timestamp}",
           "description": "Filename template for pasted images. Supported tokens: ${timestamp}, ${filename}, ${date}."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,28 +29,28 @@ export function activate(context: vscode.ExtensionContext): void {
   };
 
   // Table structure
-  register('markdownForge.alignTable',              alignTableCommand);
-  register('markdownForge.insertRowAbove',          insertRowAboveCommand);
-  register('markdownForge.insertRowBelow',          insertRowBelowCommand);
-  register('markdownForge.insertColumnLeft',        insertColumnLeftCommand);
-  register('markdownForge.insertColumnRight',       insertColumnRightCommand);
-  register('markdownForge.deleteRow',               deleteRowCommand);
-  register('markdownForge.deleteColumn',            deleteColumnCommand);
-  register('markdownForge.moveRowUp',               moveRowUpCommand);
-  register('markdownForge.moveRowDown',             moveRowDownCommand);
-  register('markdownForge.moveColumnLeft',          moveColumnLeftCommand);
-  register('markdownForge.moveColumnRight',         moveColumnRightCommand);
-  register('markdownForge.sortByColumn',            sortByColumnCommand);
-  register('markdownForge.convertSelectionToTable', convertSelectionToTableCommand);
+  register('markdownFoundry.alignTable',              alignTableCommand);
+  register('markdownFoundry.insertRowAbove',          insertRowAboveCommand);
+  register('markdownFoundry.insertRowBelow',          insertRowBelowCommand);
+  register('markdownFoundry.insertColumnLeft',        insertColumnLeftCommand);
+  register('markdownFoundry.insertColumnRight',       insertColumnRightCommand);
+  register('markdownFoundry.deleteRow',               deleteRowCommand);
+  register('markdownFoundry.deleteColumn',            deleteColumnCommand);
+  register('markdownFoundry.moveRowUp',               moveRowUpCommand);
+  register('markdownFoundry.moveRowDown',             moveRowDownCommand);
+  register('markdownFoundry.moveColumnLeft',          moveColumnLeftCommand);
+  register('markdownFoundry.moveColumnRight',         moveColumnRightCommand);
+  register('markdownFoundry.sortByColumn',            sortByColumnCommand);
+  register('markdownFoundry.convertSelectionToTable', convertSelectionToTableCommand);
 
   // Navigation
-  register('markdownForge.nextCell',     nextCellCommand);
-  register('markdownForge.previousCell', previousCellCommand);
-  register('markdownForge.nextRow',      nextRowCommand);
+  register('markdownFoundry.nextCell',     nextCellCommand);
+  register('markdownFoundry.previousCell', previousCellCommand);
+  register('markdownFoundry.nextRow',      nextRowCommand);
 
   // Insertion
-  register('markdownForge.pasteLink',  pasteLinkCommand);
-  register('markdownForge.pasteImage', pasteImageCommand);
+  register('markdownFoundry.pasteLink',  pasteLinkCommand);
+  register('markdownFoundry.pasteImage', pasteImageCommand);
 
   // Context key for Tab/Shift-Tab/Enter bindings
   registerInTableContext(context);
@@ -59,7 +59,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.workspace.onWillSaveTextDocument((event) => {
       if (event.document.languageId !== 'markdown') return;
-      const config = vscode.workspace.getConfiguration('markdownForge');
+      const config = vscode.workspace.getConfiguration('markdownFoundry');
       if (!config.get<boolean>('alignOnSave')) return;
       event.waitUntil(Promise.resolve(alignAllTablesInDocument(event.document)));
     })

--- a/src/insert/image.ts
+++ b/src/insert/image.ts
@@ -18,7 +18,7 @@ export async function pasteImageCommand(): Promise<void> {
     return;
   }
 
-  const config = vscode.workspace.getConfiguration('markdownForge');
+  const config = vscode.workspace.getConfiguration('markdownFoundry');
   const folderName = config.get<string>('imageFolder') ?? 'images';
   const nameFormat = config.get<string>('imageNameFormat') ?? 'image-${timestamp}';
 

--- a/src/table/commands/convert.ts
+++ b/src/table/commands/convert.ts
@@ -36,7 +36,7 @@ export async function convertSelectionToTableCommand(): Promise<void> {
 
   const headers = normalized[0];
   const rows = normalized.slice(1);
-  const config = vscode.workspace.getConfiguration('markdownForge');
+  const config = vscode.workspace.getConfiguration('markdownFoundry');
   const defaultAlign = (config.get<Alignment>('defaultAlignment') ?? 'left');
   const alignments: Alignment[] = Array(columnCount).fill(defaultAlign);
 

--- a/src/table/commands/rowColumn.ts
+++ b/src/table/commands/rowColumn.ts
@@ -40,7 +40,7 @@ async function transformTable(
 
 /** Get the default alignment from user config. */
 function defaultAlignment(): Alignment {
-  const config = vscode.workspace.getConfiguration('markdownForge');
+  const config = vscode.workspace.getConfiguration('markdownFoundry');
   return (config.get<Alignment>('defaultAlignment') ?? 'left');
 }
 

--- a/src/util/contextKey.ts
+++ b/src/util/contextKey.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import { locateTable } from '../table/locator';
 
-const CONTEXT_KEY = 'markdownForge.inTable';
+const CONTEXT_KEY = 'markdownFoundry.inTable';
 
 /**
- * Watch selection changes and keep the `markdownForge.inTable` context key
+ * Watch selection changes and keep the `markdownFoundry.inTable` context key
  * in sync. Used by the Tab/Shift-Tab/Enter keybindings so they only override
  * default behavior when the cursor is actually inside a table.
  */


### PR DESCRIPTION
## Summary

- Renames every camelCase `markdownForge` identifier (command IDs, configuration keys, context key, keybinding `when` clauses, related docs) to `markdownFoundry`.
- 60 literal replacements across 9 files. Pure substitution — symmetric 60/60 insert/delete stats.
- **Settings compat window** — doing this pre-publish avoids breaking users later; no settings.json migration needed because no users exist yet.

## Verification

- [x] `grep markdownForge` against tracked files returns zero matches
- [x] `grep markdownFoundry` returns ~60 matches distributed across the 9 expected files
- [x] `grep MDFORGE_IMAGE_PATH` still returns 2 matches in `src/insert/image.ts` (env var explicitly preserved)
- [x] `grep mdforge` still finds `name: "mdforge"` in `package.json` (slug preserved)
- [x] `git diff --stat`: 9 files modified, 60 insertions / 60 deletions
- [x] `node -e "JSON.parse(...)"` confirms `package.json` parses
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [ ] Manual smoke test in Extension Development Host — human verifies `Markdown Foundry: Align Table` still works from the command palette (confirms command registration path end-to-end)

## Explicitly preserved

- `name: "mdforge"` — extension URL slug
- `displayName: "Markdown Foundry"` — already correct
- `MDFORGE_IMAGE_PATH` — internal env var used by Windows clipboard shell-out
- GitHub repo name `dvlprlife/Markdown-Forge`
- `agents/**`, icon, LICENSE (none contain the namespace literal)

Closes #32