### PR TITLE
Rename extension slug from mdforge to mdfoundry for brand consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mdforge",
+  "name": "mdfoundry",
   "displayName": "Markdown Foundry",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
   "version": "0.1.0",

--- a/src/insert/image.ts
+++ b/src/insert/image.ts
@@ -82,7 +82,7 @@ const WINDOWS_CLIPBOARD_SCRIPT =
   "Add-Type -AssemblyName System.Windows.Forms, System.Drawing; " +
   "$img = [System.Windows.Forms.Clipboard]::GetImage(); " +
   "if ($null -eq $img) { Write-Error 'NO_IMAGE'; exit 1 } " +
-  "$img.Save($env:MDFORGE_IMAGE_PATH, [System.Drawing.Imaging.ImageFormat]::Png)";
+  "$img.Save($env:MDFOUNDRY_IMAGE_PATH, [System.Drawing.Imaging.ImageFormat]::Png)";
 
 async function saveClipboardImageWindows(targetPath: string): Promise<void> {
   try {
@@ -92,7 +92,7 @@ async function saveClipboardImageWindows(targetPath: string): Promise<void> {
       'powershell.exe',
       ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_CLIPBOARD_SCRIPT],
       {
-        env: { ...process.env, MDFORGE_IMAGE_PATH: targetPath },
+        env: { ...process.env, MDFOUNDRY_IMAGE_PATH: targetPath },
         windowsHide: true,
       }
     );


### PR DESCRIPTION
## Summary

- Renames `package.json` `name` field from `mdforge` to `mdfoundry` (1 line) and the internal Windows clipboard env var `MDFORGE_IMAGE_PATH` to `MDFOUNDRY_IMAGE_PATH` (2 sites in `src/insert/image.ts`).
- Completes the Markdown Foundry rebrand — no `mdforge` or `MDFORGE` tokens remain anywhere in the tracked repo.
- Extension ID will become `dvlprlife.mdfoundry`; packaged artifact becomes `mdfoundry-0.1.0.vsix`.

## Verification

- [x] `git diff --stat`: 2 files modified, 3 insertions / 3 deletions
- [x] `Grep` for `mdforge` (case-sensitive) across tracked files → 0 matches
- [x] `Grep` for `MDFORGE` across tracked files → 0 matches
- [x] `src/insert/image.ts` contains 2 `MDFOUNDRY_IMAGE_PATH` references at lines 85 (PowerShell script reads `$env:MDFOUNDRY_IMAGE_PATH`) and 95 (Node `execFile` env option sets `MDFOUNDRY_IMAGE_PATH: targetPath`) — handshake sites match
- [x] Every other field in `package.json` unchanged (`displayName: "Markdown Foundry"`, version, publisher, description, repository, engines, contributes.* all untouched)
- [x] `node -e "JSON.parse(...)"` confirms `package.json` still parses
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [ ] Manual smoke test post-merge: F5 → paste image on Windows still works (confirms the renamed env var works end-to-end)

Closes #36