### PR TITLE
Update in-repo references from Markdown-Forge to Markdown-Foundry after GitHub repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Markdown Foundry makes working with tables fast and ergonomic — align columns,
 ### Insertion commands
 
 - **Paste Link** — If the clipboard contains a URL, wrap the selection (or prompt for text) and insert `[text](url)`.
-- **Paste Image** — Save the clipboard image to a configurable folder and insert a Markdown image reference. *Windows only in v0.x; macOS and Linux support is tracked in [#4](https://github.com/dvlprlife/Markdown-Forge/issues/4) and [#5](https://github.com/dvlprlife/Markdown-Forge/issues/5).*
+- **Paste Image** — Save the clipboard image to a configurable folder and insert a Markdown image reference. *Windows only in v0.x; macOS and Linux support is tracked in [#4](https://github.com/dvlprlife/Markdown-Foundry/issues/4) and [#5](https://github.com/dvlprlife/Markdown-Foundry/issues/5).*
 
 ## Keybindings
 
@@ -56,7 +56,7 @@ All other commands are available through the Command Palette (search for "Markdo
 
 ## Issues and feedback
 
-Please file issues and feature requests on [GitHub](https://github.com/dvlprlife/Markdown-Forge).
+Please file issues and feature requests on [GitHub](https://github.com/dvlprlife/Markdown-Foundry).
 
 ## License
 

--- a/agents/WORKFLOW.md
+++ b/agents/WORKFLOW.md
@@ -1,6 +1,6 @@
 # Agent Workflow
 
-This document describes the full lifecycle of an issue through the agent system for the `dvlprlife/Markdown-Forge` repository.
+This document describes the full lifecycle of an issue through the agent system for the `dvlprlife/Markdown-Foundry` repository.
 
 ## Agents
 

--- a/agents/issue-planner.md
+++ b/agents/issue-planner.md
@@ -1,11 +1,11 @@
 # Issue Planner Agent
 
-You are an autonomous agent that reviews GitHub issues and writes implementation plans for the `dvlprlife/Markdown-Forge` repository.
+You are an autonomous agent that reviews GitHub issues and writes implementation plans for the `dvlprlife/Markdown-Foundry` repository.
 
 ## Step 1: Find Eligible Issues
 
 ```
-gh issue list --repo dvlprlife/Markdown-Forge --label "agent" --label "status: need plan" --state open --json number,title,body,labels
+gh issue list --repo dvlprlife/Markdown-Foundry --label "agent" --label "status: need plan" --state open --json number,title,body,labels
 ```
 
 If no issues are returned, report "No issues need planning." and stop.
@@ -15,7 +15,7 @@ If no issues are returned, report "No issues need planning." and stop.
 For the first eligible issue found:
 
 ```
-gh issue view {number} --repo dvlprlife/Markdown-Forge
+gh issue view {number} --repo dvlprlife/Markdown-Foundry
 ```
 
 ## Step 3: Assess if a Plan Can Be Written
@@ -26,12 +26,12 @@ Determine if the issue body contains enough information to write a concrete impl
 
 1. Add `status: follow up` and `human` labels, remove `agent` label:
    ```
-   gh issue edit {number} --repo dvlprlife/Markdown-Forge --add-label "status: follow up" --add-label "human" --remove-label "agent"
+   gh issue edit {number} --repo dvlprlife/Markdown-Foundry --add-label "status: follow up" --add-label "human" --remove-label "agent"
    ```
 
 2. Post a comment explaining what is missing:
    ```
-   gh issue comment {number} --repo dvlprlife/Markdown-Forge --body "## Needs Clarification
+   gh issue comment {number} --repo dvlprlife/Markdown-Foundry --body "## Needs Clarification
 
    {explanation of what information is needed to write a plan}"
    ```
@@ -43,7 +43,7 @@ Determine if the issue body contains enough information to write a concrete impl
 ## Step 4: Post Implementation Plan Comment
 
 ```
-gh issue comment {number} --repo dvlprlife/Markdown-Forge --body "## Implementation Plan
+gh issue comment {number} --repo dvlprlife/Markdown-Foundry --body "## Implementation Plan
 
 {bullet list of specific changes, file by file, with enough detail for the issue worker to execute}
 
@@ -57,7 +57,7 @@ gh issue comment {number} --repo dvlprlife/Markdown-Forge --body "## Implementat
 Remove `status: need plan` and add `status: ready` so the issue worker can pick it up:
 
 ```
-gh issue edit {number} --repo dvlprlife/Markdown-Forge --remove-label "status: need plan" --add-label "status: ready"
+gh issue edit {number} --repo dvlprlife/Markdown-Foundry --remove-label "status: need plan" --add-label "status: ready"
 ```
 
 ## Rules

--- a/agents/issue-worker.md
+++ b/agents/issue-worker.md
@@ -1,12 +1,12 @@
 # Issue Worker Agent
 
-You are an autonomous agent that finds and works GitHub issues for the `dvlprlife/Markdown-Forge` repository.
+You are an autonomous agent that finds and works GitHub issues for the `dvlprlife/Markdown-Foundry` repository.
 
 ## Step 1: Find Eligible Issues
 
 Run:
 ```
-gh issue list --repo dvlprlife/Markdown-Forge --label "agent" --label "status: ready" --state open --json number,title,body,labels
+gh issue list --repo dvlprlife/Markdown-Foundry --label "agent" --label "status: ready" --state open --json number,title,body,labels
 ```
 
 If no issues are returned, report "No issues ready for agent processing." and stop.
@@ -17,24 +17,24 @@ For the first eligible issue found:
 
 1. **Mark it in-progress immediately** so no other agent picks it up:
    ```
-   gh issue edit {number} --repo dvlprlife/Markdown-Forge --add-label "status: in-progress" --remove-label "status: ready"
+   gh issue edit {number} --repo dvlprlife/Markdown-Foundry --add-label "status: in-progress" --remove-label "status: ready"
    ```
 
 2. **Read the full issue** to understand exactly what needs to be done:
    ```
-   gh issue view {number} --repo dvlprlife/Markdown-Forge
+   gh issue view {number} --repo dvlprlife/Markdown-Foundry
    ```
 
 ## Step 3: Verify an Implementation Plan Exists
 
 Check that an "## Implementation Plan" comment already exists on the issue:
 ```
-gh issue view {number} --repo dvlprlife/Markdown-Forge --comments
+gh issue view {number} --repo dvlprlife/Markdown-Foundry --comments
 ```
 
 If **no Implementation Plan comment is found**: transition the issue back to `status: need plan` and stop:
 ```
-gh issue edit {number} --repo dvlprlife/Markdown-Forge --remove-label "status: in-progress" --add-label "status: need plan"
+gh issue edit {number} --repo dvlprlife/Markdown-Foundry --remove-label "status: in-progress" --add-label "status: need plan"
 ```
 
 If a plan comment exists: proceed.
@@ -77,7 +77,7 @@ git push -u origin issue-{number}-short-description
 ## Step 7: Open a PR
 
 ```
-gh pr create --repo dvlprlife/Markdown-Forge \
+gh pr create --repo dvlprlife/Markdown-Foundry \
   --title "{issue title}" \
   --body "## Summary
 {brief description of what was changed}
@@ -89,14 +89,14 @@ Closes #{number}"
 
 After the PR is opened, update the issue label to reflect it is awaiting human review:
 ```
-gh issue edit {number} --repo dvlprlife/Markdown-Forge --add-label "status: in-review" --remove-label "status: in-progress"
+gh issue edit {number} --repo dvlprlife/Markdown-Foundry --add-label "status: in-review" --remove-label "status: in-progress"
 ```
 
 ## Step 9: Comment on the Issue
 
 Post a comment linking to the PR so the issue is traceable:
 ```
-gh issue comment {number} --repo dvlprlife/Markdown-Forge --body "PR opened: {pr_url}"
+gh issue comment {number} --repo dvlprlife/Markdown-Foundry --body "PR opened: {pr_url}"
 ```
 
 ## Rules

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,11 +1,11 @@
 # PR Reviewer Agent
 
-You are an autonomous agent that reviews open pull requests for the `dvlprlife/Markdown-Forge` repository. You check each PR against the Implementation Plan, the issue's Acceptance Criteria, code quality, and CLAUDE.md compliance, then report findings on both the PR and the linked issue.
+You are an autonomous agent that reviews open pull requests for the `dvlprlife/Markdown-Foundry` repository. You check each PR against the Implementation Plan, the issue's Acceptance Criteria, code quality, and CLAUDE.md compliance, then report findings on both the PR and the linked issue.
 
 ## Step 1: Find Eligible Issues
 
 ```
-gh issue list --repo dvlprlife/Markdown-Forge --label "agent" --label "status: in-review" --state open --json number,title,body
+gh issue list --repo dvlprlife/Markdown-Foundry --label "agent" --label "status: in-review" --state open --json number,title,body
 ```
 
 If no issues are returned, report "No PRs awaiting review." and stop.
@@ -15,13 +15,13 @@ If no issues are returned, report "No PRs awaiting review." and stop.
 For the first eligible issue:
 
 ```
-gh pr list --repo dvlprlife/Markdown-Forge --state open --search "Closes #{number} in:body" --json number,url,headRefName,author
+gh pr list --repo dvlprlife/Markdown-Foundry --state open --search "Closes #{number} in:body" --json number,url,headRefName,author
 ```
 
 If no PR is found, post a note on the issue and skip to the next eligible issue (do not invent a PR):
 
 ```
-gh issue comment {number} --repo dvlprlife/Markdown-Forge --body "## Review Skipped
+gh issue comment {number} --repo dvlprlife/Markdown-Foundry --body "## Review Skipped
 
 No open PR references this issue with \`Closes #{number}\`. Re-check once the worker opens the PR."
 ```
@@ -31,9 +31,9 @@ No open PR references this issue with \`Closes #{number}\`. Re-check once the wo
 Pull everything needed to compare the PR against the plan and the issue:
 
 ```
-gh issue view {issue_number} --repo dvlprlife/Markdown-Forge --comments
-gh pr view {pr_number} --repo dvlprlife/Markdown-Forge
-gh pr diff {pr_number} --repo dvlprlife/Markdown-Forge
+gh issue view {issue_number} --repo dvlprlife/Markdown-Foundry --comments
+gh pr view {pr_number} --repo dvlprlife/Markdown-Foundry
+gh pr diff {pr_number} --repo dvlprlife/Markdown-Foundry
 ```
 
 From the issue, extract:
@@ -52,7 +52,7 @@ From the issue, extract:
 **If findings exist:** request changes. Fall back to a comment review if GitHub blocks `--request-changes` (e.g. same-author PRs):
 
 ```
-gh pr review {pr_number} --repo dvlprlife/Markdown-Forge --request-changes --body "## Automated Review
+gh pr review {pr_number} --repo dvlprlife/Markdown-Foundry --request-changes --body "## Automated Review
 
 ### Findings
 {bulleted list of issues, each labeled by category: Plan / AC / Quality / CLAUDE.md, citing file paths and line numbers}
@@ -64,13 +64,13 @@ gh pr review {pr_number} --repo dvlprlife/Markdown-Forge --request-changes --bod
 If `--request-changes` fails:
 
 ```
-gh pr review {pr_number} --repo dvlprlife/Markdown-Forge --comment --body "..."
+gh pr review {pr_number} --repo dvlprlife/Markdown-Foundry --comment --body "..."
 ```
 
 **If the PR looks good:** post a comment review (agents cannot self-approve):
 
 ```
-gh pr review {pr_number} --repo dvlprlife/Markdown-Forge --comment --body "## Automated Review
+gh pr review {pr_number} --repo dvlprlife/Markdown-Foundry --comment --body "## Automated Review
 
 All four criteria satisfied:
 - Plan adherence: ✓
@@ -84,7 +84,7 @@ Ready for human approval."
 ## Step 6: Summarize on the Issue
 
 ```
-gh issue comment {issue_number} --repo dvlprlife/Markdown-Forge --body "## Review Summary
+gh issue comment {issue_number} --repo dvlprlife/Markdown-Foundry --body "## Review Summary
 
 PR: {pr_url}
 
@@ -96,13 +96,13 @@ PR: {pr_url}
 **If findings were posted:** add `status: follow up` and `human`, remove `status: in-review`:
 
 ```
-gh issue edit {issue_number} --repo dvlprlife/Markdown-Forge --add-label "status: follow up" --add-label "human" --remove-label "status: in-review"
+gh issue edit {issue_number} --repo dvlprlife/Markdown-Foundry --add-label "status: follow up" --add-label "human" --remove-label "status: in-review"
 ```
 
 **If the PR was clean:** add `status: agent approved`, remove `status: in-review`:
 
 ```
-gh issue edit {issue_number} --repo dvlprlife/Markdown-Forge --add-label "status: agent approved" --remove-label "status: in-review"
+gh issue edit {issue_number} --repo dvlprlife/Markdown-Foundry --add-label "status: agent approved" --remove-label "status: in-review"
 ```
 
 ## Rules

--- a/agents/repo-check.md
+++ b/agents/repo-check.md
@@ -1,11 +1,11 @@
 # Repo Check Agent
 
-You are an agent that ensures all required GitHub labels exist in the `dvlprlife/Markdown-Forge` repository.
+You are an agent that ensures all required GitHub labels exist in the `dvlprlife/Markdown-Foundry` repository.
 
 ## Step 1: List Existing Labels
 
 ```
-gh label list --repo dvlprlife/Markdown-Forge --json name --limit 100
+gh label list --repo dvlprlife/Markdown-Foundry --json name --limit 100
 ```
 
 ## Step 2: Check and Create Required Labels
@@ -14,14 +14,14 @@ For each label in the list below, check if it exists in the output from Step 1. 
 
 | Label | Color | Description | Create command |
 |-------|-------|-------------|----------------|
-| `agent` | `#0075ca` | Issue is assigned to an agent for automated processing | `gh label create "agent" --repo dvlprlife/Markdown-Forge --color "0075ca" --description "Issue is assigned to an agent for automated processing"` |
-| `status: ready` | `#0e8a16` | Issue is ready to be picked up | `gh label create "status: ready" --repo dvlprlife/Markdown-Forge --color "0e8a16" --description "Issue is ready to be picked up"` |
-| `status: in-progress` | `#e4e669` | Issue is currently being worked on | `gh label create "status: in-progress" --repo dvlprlife/Markdown-Forge --color "e4e669" --description "Issue is currently being worked on"` |
-| `status: in-review` | `#d93f0b` | Issue has an open PR awaiting review | `gh label create "status: in-review" --repo dvlprlife/Markdown-Forge --color "d93f0b" --description "Issue has an open PR awaiting review"` |
-| `status: follow up` | `#c5def5` | Needs follow-up after completion | `gh label create "status: follow up" --repo dvlprlife/Markdown-Forge --color "c5def5" --description "Needs follow-up after completion"` |
-| `human` | `#b60205` | Requires human attention or intervention | `gh label create "human" --repo dvlprlife/Markdown-Forge --color "b60205" --description "Requires human attention or intervention"` |
-| `status: need plan` | `#fbca04` | Issue needs a plan before work can begin | `gh label create "status: need plan" --repo dvlprlife/Markdown-Forge --color "fbca04" --description "Issue needs a plan before work can begin"` |
-| `status: agent approved` | `#2da44e` | PR reviewer agent found no issues; awaiting human approval | `gh label create "status: agent approved" --repo dvlprlife/Markdown-Forge --color "2da44e" --description "PR reviewer agent found no issues; awaiting human approval"` |
+| `agent` | `#0075ca` | Issue is assigned to an agent for automated processing | `gh label create "agent" --repo dvlprlife/Markdown-Foundry --color "0075ca" --description "Issue is assigned to an agent for automated processing"` |
+| `status: ready` | `#0e8a16` | Issue is ready to be picked up | `gh label create "status: ready" --repo dvlprlife/Markdown-Foundry --color "0e8a16" --description "Issue is ready to be picked up"` |
+| `status: in-progress` | `#e4e669` | Issue is currently being worked on | `gh label create "status: in-progress" --repo dvlprlife/Markdown-Foundry --color "e4e669" --description "Issue is currently being worked on"` |
+| `status: in-review` | `#d93f0b` | Issue has an open PR awaiting review | `gh label create "status: in-review" --repo dvlprlife/Markdown-Foundry --color "d93f0b" --description "Issue has an open PR awaiting review"` |
+| `status: follow up` | `#c5def5` | Needs follow-up after completion | `gh label create "status: follow up" --repo dvlprlife/Markdown-Foundry --color "c5def5" --description "Needs follow-up after completion"` |
+| `human` | `#b60205` | Requires human attention or intervention | `gh label create "human" --repo dvlprlife/Markdown-Foundry --color "b60205" --description "Requires human attention or intervention"` |
+| `status: need plan` | `#fbca04` | Issue needs a plan before work can begin | `gh label create "status: need plan" --repo dvlprlife/Markdown-Foundry --color "fbca04" --description "Issue needs a plan before work can begin"` |
+| `status: agent approved` | `#2da44e` | PR reviewer agent found no issues; awaiting human approval | `gh label create "status: agent approved" --repo dvlprlife/Markdown-Foundry --color "2da44e" --description "PR reviewer agent found no issues; awaiting human approval"` |
 
 ## Step 3: Report Results
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "icon": "images/icon.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dvlprlife/Markdown-Forge"
+    "url": "https://github.com/dvlprlife/Markdown-Foundry"
   },
   "activationEvents": [
     "onLanguage:markdown"


### PR DESCRIPTION
## Summary

- Updates all 43 hardcoded `dvlprlife/Markdown-Forge` references to `dvlprlife/Markdown-Foundry` across 7 files: `package.json`, `README.md`, and 5 `agents/*.md` files.
- Follows the GitHub repo rename (completed out-of-band). GitHub maintains a redirect from the old URL, but the canonical name should be in all tracked references.
- No behavioral change; no source touched.

## Verification

- [x] `grep Markdown-Forge` across tracked files returns zero matches
- [x] `grep dvlprlife/Markdown-Foundry` returns 43 matches distributed as planned (README=2, package.json=1, WORKFLOW=1, repo-check=10, pr-reviewer=13, issue-worker=9, issue-planner=7)
- [x] `git diff --stat`: 7 files modified, 43 insertions / 43 deletions (symmetric)
- [x] `node -e "JSON.parse(...)"` confirms `package.json` still parses
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [x] No source, LICENSE, CHANGELOG, CLAUDE.md, or images/ changes

Closes #38