### PR TITLE
Update marketplace keywords and bump to v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdfoundry",
   "displayName": "Markdown Foundry",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "dvlprlife",
   "license": "MIT",
   "engines": {
@@ -17,8 +17,13 @@
     "table",
     "tables",
     "formatter",
-    "authoring",
-    "md"
+    "csv",
+    "tsv",
+    "align",
+    "sort",
+    "navigation",
+    "gfm",
+    "editor"
   ],
   "icon": "images/icon.png",
   "repository": {


### PR DESCRIPTION
## Summary

- Swaps 2 low-signal keywords (`md`, `authoring`) for 7 high-signal keywords (`csv`, `tsv`, `align`, `sort`, `navigation`, `gfm`, `editor`). Final count: 11.
- Bumps `version` from `0.1.0` to `0.1.1` so the change can be published.
- Ships as a standalone metadata patch release — marketplace re-indexes keywords within minutes, so decoupling from v0.2.0 features gets users finding the extension sooner.

## Verification

- [x] `package.json` `version` is `"0.1.1"`
- [x] `package.json` `keywords` contains exactly the 11 planned entries in order; does not contain `authoring` or `md`
- [x] JSON validates via `node -e "const p=require('./package.json'); ...check structure..."` (script in PR plan)
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [x] Only `package.json` modified — no source, README, CHANGELOG, or other file touched
- [x] `git diff package.json` shows exactly the expected 2 changes (version line + keywords block)

## CHANGELOG

The `CHANGELOG.md` is explicitly NOT updated in this PR. It currently has a stale `[0.1.0] - Unreleased` header (we already published v0.1.0) and a proper fix for it — plus a new `[0.1.1]` entry — deserves its own dedicated pass. Tracked separately.

## Post-merge publish flow

1. `vsce package` → produces `mdfoundry-0.1.1.vsix` (version bump changes the filename)
2. `vsce ls` → confirm contents unchanged from v0.1.0 (9 user-facing files)
3. `vsce publish --packagePath mdfoundry-0.1.1.vsix`

Closes #40