### PR TITLE
Implement saveClipboardImage for macOS

### DIFF
--- a/src/insert/image.ts
+++ b/src/insert/image.ts
@@ -70,7 +70,7 @@ async function saveClipboardImage(targetPath: string): Promise<void> {
     case 'win32':
       return saveClipboardImageWindows(targetPath);
     case 'darwin':
-      throw new Error('Clipboard image paste is not yet supported on macOS.');
+      return saveClipboardImageMacOS(targetPath);
     case 'linux':
       throw new Error('Clipboard image paste is not yet supported on Linux.');
     default:
@@ -103,6 +103,38 @@ async function saveClipboardImageWindows(targetPath: string): Promise<void> {
       throw new Error('Clipboard does not contain an image.');
     }
     throw new Error(`powershell failed: ${message}`);
+  }
+}
+
+const MACOS_CLIPBOARD_SCRIPT = [
+  'try',
+  '  set targetPath to (system attribute "MDFOUNDRY_IMAGE_PATH")',
+  '  set pngData to the clipboard as «class PNGf»',
+  '  set fp to open for access (POSIX file targetPath) with write permission',
+  '  set eof of fp to 0',
+  '  write pngData to fp',
+  '  close access fp',
+  'on error',
+  '  error "NO_IMAGE" number 1',
+  'end try',
+].join('\n');
+
+async function saveClipboardImageMacOS(targetPath: string): Promise<void> {
+  try {
+    await execFileAsync(
+      'osascript',
+      ['-e', MACOS_CLIPBOARD_SCRIPT],
+      {
+        env: { ...process.env, MDFOUNDRY_IMAGE_PATH: targetPath },
+      }
+    );
+  } catch (err) {
+    const stderr = readStderr(err);
+    const message = err instanceof Error ? err.message : String(err);
+    if (stderr.includes('NO_IMAGE') || message.includes('NO_IMAGE')) {
+      throw new Error('Clipboard does not contain an image.');
+    }
+    throw new Error(`osascript failed: ${message}`);
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `saveClipboardImageMacOS` to `src/insert/image.ts`. Dispatches on `process.platform === 'darwin'`; shells out to `osascript` with an inline AppleScript that reads the clipboard as `«class PNGf»` and writes to `targetPath` via the env var `MDFOUNDRY_IMAGE_PATH`.
- Mirrors the Windows handler pattern exactly (including `NO_IMAGE` sentinel + `readStderr` reuse).
- Linux branch unchanged (tracked in issue #5, next up).

## Deviation from the approved plan

The plan (posted pre-rebrand) referenced env var `MDFORGE_IMAGE_PATH`. Current codebase uses `MDFOUNDRY_IMAGE_PATH` (PR #37). The worker applied the current identifier so the macOS code matches the Windows handler it mirrors — changing `MDFORGE_IMAGE_PATH` in this PR while Windows uses `MDFOUNDRY_IMAGE_PATH` would have been incoherent. Flagged per the draft-deviation pattern used on earlier PRs.

## Verification

- [x] `git diff` is exactly one file, one net-additive change (33 insertions, 1 deletion — the deletion is the old `throw` on the darwin branch)
- [x] `darwin` branch now calls `saveClipboardImageMacOS(targetPath)`
- [x] `win32` behavior unchanged (code path untouched)
- [x] `linux` branch still throws the "not yet supported" loud stub (tracked in #5)
- [x] `MACOS_CLIPBOARD_SCRIPT` constant mirrors the plan (AppleScript try/on-error with `error "NO_IMAGE" number 1` sentinel)
- [x] `saveClipboardImageMacOS` reuses the existing `readStderr` helper, matches the Windows error-mapping shape (`'NO_IMAGE'` → "Clipboard does not contain an image."), uses the `MDFOUNDRY_IMAGE_PATH` env var for path transport
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [ ] Manual test on macOS — cannot be run on the development machine (Windows ARM64). Human merger with Mac access: `Cmd+Ctrl+Shift+4` to snip to clipboard → open a saved `.md` → run `Markdown Foundry: Paste Image` → confirm PNG written under `images/` and `![](images/...)` inserted with forward slashes. If no Mac is available, recommend merging on trust of code review + the symmetry argument (identical control flow to the Windows handler, which is tested and shipped).

Closes #4