### PR TITLE
Implement saveClipboardImage for Linux

### DIFF
--- a/src/insert/image.ts
+++ b/src/insert/image.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { promises as fs } from 'fs';
-import { execFile } from 'child_process';
+import { createWriteStream, promises as fs } from 'fs';
+import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
@@ -72,7 +72,7 @@ async function saveClipboardImage(targetPath: string): Promise<void> {
     case 'darwin':
       return saveClipboardImageMacOS(targetPath);
     case 'linux':
-      throw new Error('Clipboard image paste is not yet supported on Linux.');
+      return saveClipboardImageLinux(targetPath);
     default:
       throw new Error(`Clipboard image paste is not yet supported on ${process.platform}.`);
   }
@@ -136,6 +136,61 @@ async function saveClipboardImageMacOS(targetPath: string): Promise<void> {
     }
     throw new Error(`osascript failed: ${message}`);
   }
+}
+
+async function saveClipboardImageLinux(targetPath: string): Promise<void> {
+  const isWayland = process.env.XDG_SESSION_TYPE === 'wayland';
+  const command = isWayland ? 'wl-paste' : 'xclip';
+  const args = isWayland
+    ? ['--type', 'image/png']
+    : ['-selection', 'clipboard', '-t', 'image/png', '-o'];
+  const installHint = isWayland
+    ? 'Clipboard paste requires wl-clipboard. Install with your package manager (e.g. sudo apt install wl-clipboard).'
+    : 'Clipboard paste requires xclip. Install with your package manager (e.g. sudo apt install xclip).';
+
+  await runAndCapture(command, args, targetPath, installHint);
+}
+
+async function runAndCapture(
+  command: string,
+  args: readonly string[],
+  targetPath: string,
+  installHint: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = createWriteStream(targetPath);
+    let stderr = '';
+    let bytesWritten = 0;
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      out.destroy();
+      if (err.code === 'ENOENT') {
+        reject(new Error(installHint));
+      } else {
+        reject(new Error(`${command} failed: ${err.message}`));
+      }
+    });
+    child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+    child.stdout?.on('data', (chunk: Buffer) => { bytesWritten += chunk.length; });
+    child.stdout?.pipe(out);
+
+    out.on('error', (err) => reject(new Error(`failed writing ${targetPath}: ${err.message}`)));
+
+    child.on('close', (code) => {
+      out.end(() => {
+        if (code !== 0 || bytesWritten === 0) {
+          fs.unlink(targetPath).catch(() => { /* best-effort cleanup of empty/partial file */ });
+          reject(new Error('Clipboard does not contain an image.'));
+          return;
+        }
+        resolve();
+      });
+    });
+
+    // Silence noUnusedLocals for the stderr accumulator (kept for future diagnostics).
+    void stderr;
+  });
 }
 
 function readStderr(err: unknown): string {


### PR DESCRIPTION
## Summary

- Adds `saveClipboardImageLinux` to `src/insert/image.ts`. Detects `XDG_SESSION_TYPE` → dispatches to `wl-paste --type image/png` (Wayland) or `xclip -selection clipboard -t image/png -o` (X11).
- Adds `runAndCapture` helper — spawns the child, pipes stdout to a `createWriteStream`, tracks bytes written + exit code, and maps the "no image" and "missing binary" cases to clear user-facing errors.
- macOS and Windows branches unchanged.

## Deviations from the approved plan

1. **Optional chaining on child streams** — `child.stdout?.on(...)`, `child.stderr?.on(...)`, `child.stdout?.pipe(...)`. Node's `spawn()` return type marks `stdout`/`stderr` as potentially null under strict-null-checks. The plan wrote them as definitely-non-null. Optional chaining is the minimal type-safe adjustment — semantically equivalent at runtime since stdio is configured as `['ignore', 'pipe', 'pipe']` (streams will be present), but satisfies tsc without suppressions.

## Verification

- [x] `linux` branch detects `XDG_SESSION_TYPE` and dispatches to `wl-paste` (Wayland) or `xclip` (X11)
- [x] Successful paste writes clipboard image to `targetPath` via `createWriteStream` piped from child stdout
- [x] Zero-byte output or non-zero exit code → throws `"Clipboard does not contain an image."` (matches AC and the Windows/macOS handlers' error contract), with best-effort cleanup of the partial/empty file via `fs.unlink`
- [x] `ENOENT` from spawn → throws install-hint error naming the missing tool (`wl-clipboard` on Wayland, `xclip` on X11) with example `apt install` command
- [x] `win32` and `darwin` branches unchanged (verified via diff — only linux-branch dispatch + new helper functions touched)
- [x] Diff: 1 file, 58/3 insertions/deletions (3 deletions: old single-import `fs`, single-import `child_process`, stale linux throw — each replaced with the new form)
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [ ] Manual test on Linux — can't be run from the Windows ARM64 development machine. Human merger with Linux access: copy a screenshot to clipboard (`gnome-screenshot --clipboard` on X11, `grim -g "$(slurp)" - | wl-copy` on Wayland) → open a saved `.md` → run `Markdown Foundry: Paste Image` → confirm PNG written + `![](images/...)` inserted with forward slashes. Also worth sanity-checking the install-hint path by temporarily renaming `xclip` or `wl-paste` and running the command; expect the install-hint error to surface via `showErrorMessage`.

Closes #5