### PR TITLE
Codify CHANGELOG discipline in CLAUDE.md and agent workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,35 @@ These are non-negotiable:
 - New table commands should have at least one integration-style test exercising the full parse → transform → format pipeline.
 - Don't delete failing tests to make CI pass. Fix the code or the test, with a commit message that explains which.
 
+## CHANGELOG maintenance
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and is the public record of what users get in each version. Every PR that lands a **user-visible change** updates it.
+
+**What counts as user-visible** (entry required):
+
+- New commands, settings, or keybindings
+- Behavior changes to existing commands or settings
+- Bug fixes to user-facing features
+- Marketplace metadata that affects discoverability or listing copy (displayName, description, keywords, icon)
+
+**What does NOT count** (no entry needed):
+
+- Internal refactors with no behavior change
+- Test-only changes
+- CI workflow, `.gitignore`, `.vscodeignore` updates
+- Contributor-facing docs (`CLAUDE.md`, `agents/**`, `CONTEXT.md`)
+
+**How to update during development:**
+
+- Maintain a `## [Unreleased]` section at the top of `CHANGELOG.md`
+- Inside `[Unreleased]`, use the Keep-a-Changelog subsections as needed: `### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Deprecated`, `### Security`
+- Each entry is one concise line: what shipped, from the user's POV. Reference the PR number in parentheses where useful.
+
+**At release time:**
+
+- Rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` (use the actual publish date)
+- Add a fresh empty `## [Unreleased]` section above it for the next cycle
+
 ## Code style
 
 - **Default to no comments.** Only add a comment when the WHY is non-obvious (a hidden constraint, a workaround, behavior that would surprise a reader). Never explain WHAT — well-named identifiers do that.

--- a/agents/issue-worker.md
+++ b/agents/issue-worker.md
@@ -59,6 +59,8 @@ Read the issue body and the Implementation Plan comment carefully. The plan desc
 
 Make all necessary changes to satisfy the acceptance criteria. Follow all rules in `CLAUDE.md`.
 
+**CHANGELOG:** if the change is user-visible (per the classification in `CLAUDE.md` → CHANGELOG maintenance), add a one-line entry under `## [Unreleased]` in `CHANGELOG.md` as part of the same PR. Not a separate commit; bundle it with the implementation. If the change is contributor-facing only, skip the entry and note the reason in the PR body so the reviewer doesn't flag it.
+
 ## Step 6: Commit and Push
 
 Commit with a message that references the issue:

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -40,12 +40,13 @@ From the issue, extract:
 - The issue body (especially Acceptance Criteria)
 - The `## Implementation Plan` comment posted by the issue planner
 
-## Step 4: Review Against Four Criteria
+## Step 4: Review Against Five Criteria
 
 1. **Implementation Plan adherence** — does the diff match the file-by-file changes described in the plan comment?
 2. **Acceptance Criteria** — is each acceptance criterion in the issue body satisfied by the diff?
 3. **Code quality** — bugs, missing edge cases, security issues, dead code, obvious style problems.
 4. **CLAUDE.md compliance** — commit messages reference the issue, branch is named `issue-{number}-*`, TypeScript strict-mode rules upheld (no `any`, no unused locals, all returns explicit), project conventions in `CLAUDE.md` respected (locator/parser/formatter layering, forward-slash paths in inserted Markdown, stubs fail loudly rather than silently), no other violations of documented conventions.
+5. **CHANGELOG compliance** — if the PR introduces a user-visible change (new command, changed behavior, fixed bug, marketplace metadata affecting the listing), the diff must include an entry under `## [Unreleased]` in `CHANGELOG.md`. If the PR is contributor-facing only (tests, CI, `agents/`, internal docs) or a pure refactor, no entry is required — but note the skip in the review so it's a conscious choice, not an oversight.
 
 ## Step 5: Post Review on the PR
 


### PR DESCRIPTION
## Summary

- Adds a new `## CHANGELOG maintenance` section to `CLAUDE.md` describing the Keep-a-Changelog convention, user-visible vs contributor-facing classification, and the Unreleased → [X.Y.Z] rename flow at release time.
- Updates `agents/pr-reviewer.md` to list 5 review criteria (was 4), with a new "CHANGELOG compliance" check.
- Updates `agents/issue-worker.md` Step 5 to remind the worker to bundle CHANGELOG entries with the implementation PR.

3 files, 33 insertions / 1 deletion (the single deletion is the Step 4 heading number change from "Four" to "Five").

## CHANGELOG classification for this PR: skip with reason

Per the new rule being introduced, this PR is **contributor-facing only** — it modifies rules documentation (`CLAUDE.md`) and agent workflow files (`agents/pr-reviewer.md`, `agents/issue-worker.md`), none of which are shipped to end users. No `CHANGELOG.md` entry added; this skip is deliberate and explicitly flagged here for the reviewer's new CHANGELOG compliance check.

## Verification

- [x] `CLAUDE.md` has `## CHANGELOG maintenance` section placed between `## Tests` and `## Code style`, with all required subsections (user-visible classification, non-user-visible exceptions, during-development flow, at-release-time flow)
- [x] `agents/pr-reviewer.md` Step 4 heading reads "Review Against Five Criteria"; 5th item named "CHANGELOG compliance" present with the approved wording
- [x] `agents/issue-worker.md` Step 5 includes a `**CHANGELOG:**` paragraph after "Follow all rules in `CLAUDE.md`."
- [x] `git diff --stat`: exactly 3 files modified
- [x] No source, README, LICENSE, or `CHANGELOG.md` itself modified
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)

Closes #44