### PR TITLE
Bump to v0.2.0 and rewrite CHANGELOG with proper release entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,33 @@
 # Change Log
 
-All notable changes to the Markdown Foundry extension will be documented in this file.
+All notable changes to the Markdown Foundry extension will be documented in this file. This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - Unreleased
+## [Unreleased]
+
+## [0.2.0] - 2026-04-23
 
 ### Added
 
-- Align table command (`Ctrl+Shift+T` / `Cmd+Shift+T`)
-- Align all tables in document on save (opt-in via `markdownFoundry.alignOnSave`)
-- Insert/delete/move row and column commands
-- Sort table by column (ascending/descending, numeric detection)
-- Convert CSV/TSV selection to Markdown table
-- Tab / Shift+Tab navigation between table cells
-- Enter to move to the next row (creates a new row at end of table)
-- Paste Link: wrap selection with a clipboard URL
-- Paste Image: save clipboard image and insert reference (platform handlers are stubbed — see src/insert/image.ts)
+- Paste Image on macOS — shells out to `osascript` to pull the PNG from the pasteboard ([#42](https://github.com/dvlprlife/Markdown-Foundry/pull/42)).
+- Paste Image on Linux — detects `XDG_SESSION_TYPE` and dispatches to `wl-paste` (Wayland) or `xclip` (X11); includes install-hint errors when the helper binary is missing ([#43](https://github.com/dvlprlife/Markdown-Foundry/pull/43)).
+
+## [0.1.1] - 2026-04-23
+
+### Changed
+
+- Marketplace keywords refreshed for discoverability: added `csv`, `tsv`, `align`, `sort`, `navigation`, `gfm`, `editor`; removed `md` and `authoring` ([#41](https://github.com/dvlprlife/Markdown-Foundry/pull/41)).
+
+## [0.1.0] - 2026-04-23
+
+Initial public release.
+
+### Added
+
+- Align table command (`Ctrl+Shift+T` / `Cmd+Shift+T`).
+- Align all tables in document on save (opt-in via `markdownFoundry.alignOnSave`).
+- Insert, delete, and move row and column commands.
+- Sort table by column (ascending / descending, with automatic numeric detection).
+- Convert selection to table from CSV or TSV data.
+- Tab / Shift+Tab navigation between table cells; Enter moves to the next row and creates one at the end of the table if needed.
+- Paste Link: wraps the current selection or prompts for text using a URL from the clipboard.
+- Paste Image on Windows — saves the clipboard image under a configurable folder and inserts a Markdown image reference (macOS and Linux added in 0.2.0).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdfoundry",
   "displayName": "Markdown Foundry",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publisher": "dvlprlife",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

- Bumps `package.json` version `0.1.1` → `0.2.0` covering the macOS (PR #42) and Linux (PR #43) Paste Image additions.
- Rewrites `CHANGELOG.md` under the Keep-a-Changelog convention codified in PR #45: adds `[Unreleased]`, `[0.2.0]`, `[0.1.1]`, and corrects the retroactive `[0.1.0]` section (was stale `Unreleased`; Paste Image entry corrected to "on Windows" since that's what shipped).

First CHANGELOG release PR under the new rule — serves as the template for future releases.

## CHANGELOG compliance

This PR is itself the CHANGELOG release for v0.2.0 — the changes to `CHANGELOG.md` ARE the feature. User-visible: yes (the CHANGELOG is part of the marketplace listing). The new criterion 5 is therefore satisfied by the PR's own content rather than by adding an entry for itself, which would be circular.

## Verification

- [x] `package.json` `version` is `"0.2.0"` (validated via `node -e "require('./package.json')..."`)
- [x] `CHANGELOG.md` has an empty `## [Unreleased]` section at the top (line 5)
- [x] `CHANGELOG.md` has `## [0.2.0] - 2026-04-23` listing macOS (#42) and Linux (#43) Paste Image additions
- [x] `CHANGELOG.md` has `## [0.1.1] - 2026-04-23` listing the keyword refresh (#41)
- [x] `CHANGELOG.md` has `## [0.1.0] - 2026-04-23` with corrected Paste Image entry (says "on Windows", Windows-only truth)
- [x] Previous stale `## [0.1.0] - Unreleased` header is gone (grep confirms only the new `[Unreleased]` top section matches)
- [x] `git diff --stat`: 2 files modified (`CHANGELOG.md`, `package.json`)
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)

## Post-merge publish flow

1. `vsce package` → produces `mdfoundry-0.2.0.vsix`
2. `vsce ls` → confirm contents (9 user-facing files)
3. `vsce publish --packagePath mdfoundry-0.2.0.vsix`

Closes #46