### PR TITLE
Fix separator regex to accept short alignment markers (:--, --:, etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 - Paste Image on macOS — shells out to `osascript` to pull the PNG from the pasteboard ([#42](https://github.com/dvlprlife/Markdown-Foundry/pull/42)).
 - Paste Image on Linux — detects `XDG_SESSION_TYPE` and dispatches to `wl-paste` (Wayland) or `xclip` (X11); includes install-hint errors when the helper binary is missing ([#43](https://github.com/dvlprlife/Markdown-Foundry/pull/43)).
 
+### Fixed
+
+- Table commands (align, sort, insert/delete/move row/column) now recognize tables with short separator markers such as `:--` or `--:`. The locator regex previously required 3+ dashes per column, silently rejecting valid GFM tables that use 1- or 2-dash separators ([#49](https://github.com/dvlprlife/Markdown-Foundry/pull/49)).
+
 ## [0.1.1] - 2026-04-23
 
 ### Changed

--- a/src/table/locator.ts
+++ b/src/table/locator.ts
@@ -12,7 +12,7 @@ const TABLE_LINE_RE = /^\s*\|.*\|\s*$/;
  * Matches a separator row: pipes plus dashes, colons for alignment, whitespace.
  * Examples: |---|---|, |:--|--:|, | :---: | --- |
  */
-const SEPARATOR_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
+const SEPARATOR_RE = /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$/;
 
 /**
  * Result of locating a table in the document.


### PR DESCRIPTION
## Summary

- Relaxes `SEPARATOR_RE` in `src/table/locator.ts` from `-{3,}` (3+ dashes required) to `-+` (1+ dashes, matching GFM).
- Adds a `### Fixed` subsection to the pending `[0.2.0]` CHANGELOG entry.
- Parser unaffected; package.json version stays at 0.2.0 (not yet published — fix bundles into the unreleased v0.2.0).

## Verification

- [x] `src/table/locator.ts` line 15 `SEPARATOR_RE` now uses `-+` (1+ dashes) in both column patterns
- [x] `CHANGELOG.md` `[0.2.0]` section has a `### Fixed` subsection with a PR #49 link
- [x] Tables with `:--`, `--:`, `:-:`, `|-|` separators now match the regex
- [x] Tables with `|---|` or longer separators still match (no regression — `-+` is a superset of `-{3,}`)
- [x] `git diff --stat`: 2 files modified (`src/table/locator.ts`, `CHANGELOG.md`); 5 insertions / 1 deletion
- [x] No changes to `parser.ts`, `formatter.ts`, command files, or `package.json`
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [ ] Manual smoke test in dev host: cursor inside a table with `:--` separator → `Markdown Foundry: Align Table` succeeds (was failing pre-fix with "cursor is not inside a table")

## CHANGELOG compliance

User-visible bug fix — includes the required `### Fixed` entry under `[0.2.0]` per the criterion 5 rule (PR #45).

Closes #48