### PR TITLE
Bump to v0.2.1 and split CHANGELOG (separator regex fix ships as 0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,18 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-23
+
+### Fixed
+
+- Table commands (align, sort, insert/delete/move row/column) now recognize tables with short separator markers such as `:--` or `--:`. The locator regex previously required 3+ dashes per column, silently rejecting valid GFM tables that use 1- or 2-dash separators ([#49](https://github.com/dvlprlife/Markdown-Foundry/pull/49)).
+
 ## [0.2.0] - 2026-04-23
 
 ### Added
 
 - Paste Image on macOS — shells out to `osascript` to pull the PNG from the pasteboard ([#42](https://github.com/dvlprlife/Markdown-Foundry/pull/42)).
 - Paste Image on Linux — detects `XDG_SESSION_TYPE` and dispatches to `wl-paste` (Wayland) or `xclip` (X11); includes install-hint errors when the helper binary is missing ([#43](https://github.com/dvlprlife/Markdown-Foundry/pull/43)).
-
-### Fixed
-
-- Table commands (align, sort, insert/delete/move row/column) now recognize tables with short separator markers such as `:--` or `--:`. The locator regex previously required 3+ dashes per column, silently rejecting valid GFM tables that use 1- or 2-dash separators ([#49](https://github.com/dvlprlife/Markdown-Foundry/pull/49)).
 
 ## [0.1.1] - 2026-04-23
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdfoundry",
   "displayName": "Markdown Foundry",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "dvlprlife",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

- Bumps `package.json` `version` `0.2.0` → `0.2.1`.
- Splits `CHANGELOG.md`: moves the separator-regex `### Fixed` entry out of `[0.2.0]` and into a new `[0.2.1] - 2026-04-23` section. Makes the changelog accurately reflect what each version contains on the marketplace — `[0.2.0]` had only the macOS + Linux clipboard additions; `[0.2.1]` adds the regex fix.

## Verification

- [x] `package.json` `version` is `"0.2.1"`
- [x] `CHANGELOG.md` has `## [0.2.1] - 2026-04-23` with the regex `### Fixed` entry and PR #49 link
- [x] `CHANGELOG.md` `[0.2.0]` no longer contains a `### Fixed` subsection
- [x] Section ordering top-to-bottom: `[Unreleased]`, `[0.2.1]`, `[0.2.0]`, `[0.1.1]`, `[0.1.0]`
- [x] Exactly one `### Fixed` in the whole file (under `[0.2.1]`)
- [x] `git diff --stat`: 2 files (`CHANGELOG.md`, `package.json`), 7 insertions / 5 deletions (symmetric shape matches plan)
- [x] `node -e "JSON.parse(...)"` confirms `package.json` still parses
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)

## CHANGELOG compliance

This PR IS the CHANGELOG release for v0.2.1 — the CHANGELOG edits are the feature, same pattern as PR #47 (the v0.2.0 housekeeping PR). No additional `[Unreleased]` entry needed.

## Post-merge publish flow

1. `vsce package` → produces `mdfoundry-0.2.1.vsix`
2. `vsce ls` → sanity check (should match v0.2.0 bundle minus the stale regex)
3. `vsce publish --packagePath mdfoundry-0.2.1.vsix`
4. Existing v0.2.0 installs auto-update to v0.2.1 within minutes

Closes #50