### PR TITLE
Update README Paste Image bullet to reflect cross-platform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 ### Changed
 
 - Table column alignment now uses the `string-width` library for width calculation, correctly handling ZWJ emoji sequences (e.g. 👨‍👩‍👧‍👦), combining marks, variation selectors, and the full East Asian Width table — previously a hand-rolled approximation under-counted width in some Unicode cases ([#53](https://github.com/dvlprlife/Markdown-Foundry/pull/53)).
+- README Paste Image description updated: drops the stale "Windows only" note (macOS and Linux both shipped in 0.2.0) and adds a Linux dependency note for `xclip` / `wl-clipboard` ([#55](https://github.com/dvlprlife/Markdown-Foundry/pull/55)).
 
 ## [0.2.1] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Markdown Foundry makes working with tables fast and ergonomic — align columns,
 ### Insertion commands
 
 - **Paste Link** — If the clipboard contains a URL, wrap the selection (or prompt for text) and insert `[text](url)`.
-- **Paste Image** — Save the clipboard image to a configurable folder and insert a Markdown image reference. *Windows only in v0.x; macOS and Linux support is tracked in [#4](https://github.com/dvlprlife/Markdown-Foundry/issues/4) and [#5](https://github.com/dvlprlife/Markdown-Foundry/issues/5).*
+- **Paste Image** — Save the clipboard image to a configurable folder and insert a Markdown image reference. On Linux, requires `xclip` (X11) or `wl-clipboard` (Wayland) to be installed.
 
 ## Keybindings
 


### PR DESCRIPTION
## Summary

- Removes stale "Windows only in v0.x" caveat and links to closed issues #4/#5 from the Paste Image bullet in `README.md`.
- Adds a Linux dependency note (`xclip` / `wl-clipboard`) to set correct expectations before users hit the runtime install-hint error from PR #43.
- Updates CHANGELOG `[Unreleased]` → `### Changed` with a bullet linking to this PR.

## Verification

- [x] `grep "Windows only" README.md` → 0 matches
- [x] `grep "tracked in" README.md` → 0 matches (closed-issue links gone)
- [x] `grep "xclip" README.md` → 1 match; `grep "wl-clipboard"` → 1 match
- [x] `git diff --stat`: 2 files (`README.md`, `CHANGELOG.md`), 2 insertions / 1 deletion
- [x] CHANGELOG `[Unreleased]` → `### Changed` now has 2 bullets (string-width from #53 + this README update)
- [x] No source files, no `package.json`, no icon changes
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)

## CHANGELOG compliance

User-visible change (README is shipped to the marketplace listing) — bullet added under `[Unreleased]` → `### Changed` with PR link (#55).

Closes #54