### PR TITLE
Handle multi-line quoted CSV fields in convertSelectionToTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Added
+
+- `Convert Selection to Table` now handles CSV data with multi-line quoted fields — embedded newlines become `<br>` so the resulting Markdown table cell renders on one line while preserving the line break visually ([#56](https://github.com/dvlprlife/Markdown-Foundry/pull/56)).
+
 ### Changed
 
 - Table column alignment now uses the `string-width` library for width calculation, correctly handling ZWJ emoji sequences (e.g. 👨‍👩‍👧‍👦), combining marks, variation selectors, and the full East Asian Width table — previously a hand-rolled approximation under-counted width in some Unicode cases ([#53](https://github.com/dvlprlife/Markdown-Foundry/pull/53)).

--- a/src/table/commands/convert.ts
+++ b/src/table/commands/convert.ts
@@ -24,11 +24,16 @@ export async function convertSelectionToTableCommand(): Promise<void> {
   }
 
   const text = editor.document.getText(selection);
-  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
-  if (lines.length === 0) return;
-
   const delimiter = detectDelimiter(text);
-  const grid = lines.map((line) => splitLine(line, delimiter));
+
+  let grid: string[][];
+  if (delimiter === 'comma') {
+    grid = parseCsv(text);
+  } else {
+    const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+    grid = lines.map((line) => splitLine(line, delimiter));
+  }
+  if (grid.length === 0) return;
   const columnCount = Math.max(...grid.map((row) => row.length));
   const normalized = grid.map((row) =>
     row.length === columnCount ? row : [...row, ...Array(columnCount - row.length).fill('')]
@@ -64,25 +69,28 @@ function detectDelimiter(text: string): Delimiter {
   return 'whitespace';
 }
 
-/**
- * Split a line by the detected delimiter. For CSV, handle quoted fields
- * (double-quoted, with "" representing a literal quote).
- */
-function splitLine(line: string, delimiter: Delimiter): string[] {
+function splitLine(line: string, delimiter: 'tab' | 'whitespace'): string[] {
   if (delimiter === 'tab') {
     return line.split('\t').map((c) => c.trim());
   }
-  if (delimiter === 'whitespace') {
-    return line.trim().split(/\s+/);
-  }
-  // CSV
-  const cells: string[] = [];
+  return line.trim().split(/\s+/);
+}
+
+/**
+ * Parse CSV text into rows, tracking quote state across newlines so a quoted
+ * field can span multiple lines. Embedded newlines inside quoted fields become
+ * `<br>` since Markdown table cells can't contain raw line breaks.
+ */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
   let current = '';
   let inQuotes = false;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
     if (inQuotes) {
-      if (ch === '"' && line[i + 1] === '"') {
+      if (ch === '"' && text[i + 1] === '"') {
         current += '"';
         i++;
       } else if (ch === '"') {
@@ -94,13 +102,33 @@ function splitLine(line: string, delimiter: Delimiter): string[] {
       if (ch === '"') {
         inQuotes = true;
       } else if (ch === ',') {
-        cells.push(current.trim());
+        row.push(finalizeCell(current));
+        current = '';
+      } else if (ch === '\r' && text[i + 1] === '\n') {
+        row.push(finalizeCell(current));
+        rows.push(row);
+        row = [];
+        current = '';
+        i++;
+      } else if (ch === '\n' || ch === '\r') {
+        row.push(finalizeCell(current));
+        rows.push(row);
+        row = [];
         current = '';
       } else {
         current += ch;
       }
     }
   }
-  cells.push(current.trim());
-  return cells;
+  // Flush any trailing cell / row.
+  if (current.length > 0 || row.length > 0) {
+    row.push(finalizeCell(current));
+    rows.push(row);
+  }
+  // Drop trailing all-empty rows (matches prior behavior of filtering blank lines).
+  return rows.filter((r) => !(r.length === 1 && r[0].length === 0));
+}
+
+function finalizeCell(raw: string): string {
+  return raw.replace(/\r?\n/g, '<br>').trim();
 }

--- a/src/test/suite/convert.test.ts
+++ b/src/test/suite/convert.test.ts
@@ -1,0 +1,41 @@
+import * as assert from 'assert';
+import { parseCsv } from '../../table/commands/convert';
+
+suite('convert: parseCsv', () => {
+  test('parses a multi-line quoted field as a single row with embedded <br>', () => {
+    const input = 'name,notes\n"Alice","line one\nline two"';
+    const result = parseCsv(input);
+    assert.deepStrictEqual(result, [
+      ['name', 'notes'],
+      ['Alice', 'line one<br>line two']
+    ]);
+  });
+
+  test('preserves quoted commas inside a field', () => {
+    const input = 'a,b\n"hello, world",value';
+    const result = parseCsv(input);
+    assert.deepStrictEqual(result, [
+      ['a', 'b'],
+      ['hello, world', 'value']
+    ]);
+  });
+
+  test('unescapes doubled quotes inside a field', () => {
+    const input = 'a,b\n"she said ""hi""",value';
+    const result = parseCsv(input);
+    assert.deepStrictEqual(result, [
+      ['a', 'b'],
+      ['she said "hi"', 'value']
+    ]);
+  });
+
+  test('handles CRLF line endings the same as LF', () => {
+    const input = 'a,b\r\n1,2\r\n3,4';
+    const result = parseCsv(input);
+    assert.deepStrictEqual(result, [
+      ['a', 'b'],
+      ['1', '2'],
+      ['3', '4']
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `parseCsv(text)` to `src/table/commands/convert.ts` — a proper CSV tokenizer that tracks quote state across newlines, replacing the pre-existing per-line split that broke on multi-line quoted fields.
- Simplifies `splitLine` to just tab/whitespace handling (CSV branch removed; now handled by `parseCsv`).
- Multi-line quoted fields collapse their embedded newlines into `<br>` so the resulting Markdown cell renders correctly without breaking table structure.
- New `src/test/suite/convert.test.ts` covers the multi-line case plus regressions on quoted commas, doubled-quote escaping, and CRLF inputs.

## Verification

- [x] CSV selection with multi-line quoted field converts into a single row with embedded newlines → `<br>` (covered by the new test case)
- [x] Existing single-line CSV behavior unchanged — quoted commas and doubled-quote escaping still work (covered by regression tests)
- [x] TSV and whitespace conversion paths untouched — still use `splitLine`
- [x] New test file `src/test/suite/convert.test.ts` added with 4 test cases; existing `parser.test.ts` and `formatter.test.ts` unaffected
- [x] `parseCsv` exported from `convert.ts` so tests can exercise it directly without going through the full command
- [x] `git diff --stat`: 3 files modified, scope confined to `src/table/commands/convert.ts`, new test file, and `CHANGELOG.md`
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [ ] Manual smoke test in dev host: paste a CSV with a multi-line quoted field, select, run `Markdown Foundry: Convert Selection to Table` — verify result is one header + one data row with `<br>` inside the multi-line cell (human-only)

## CHANGELOG compliance

User-visible feature — `### Added` entry appended under `## [Unreleased]` in `CHANGELOG.md`, linking to this PR (#56). `[Unreleased]` now accumulates: string-width (#53), README paste-image update (#55), and multi-line CSV (this PR) — all staged for the next release housekeeping PR.

Closes #7