### PR TITLE
Add formatting toggle commands (bold, italic, blockquote, block code, strikethrough)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Added
 
+- Formatting toggles: bold (`Ctrl/Cmd+B`), italic (`Ctrl/Cmd+I`), bold+italic, blockquote, block code (fenced), strikethrough. Wrap the selection or insert empty markers at the cursor ([#58](https://github.com/dvlprlife/Markdown-Foundry/pull/58)).
 - `Convert Selection to Table` now handles CSV data with multi-line quoted fields — embedded newlines become `<br>` so the resulting Markdown table cell renders on one line while preserving the line break visually ([#56](https://github.com/dvlprlife/Markdown-Foundry/pull/56)).
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -53,7 +53,13 @@
       { "command": "markdownFoundry.previousCell",            "title": "Previous Cell",             "category": "Markdown Foundry" },
       { "command": "markdownFoundry.nextRow",                 "title": "Next Row",                  "category": "Markdown Foundry" },
       { "command": "markdownFoundry.pasteLink",               "title": "Paste Link",                "category": "Markdown Foundry" },
-      { "command": "markdownFoundry.pasteImage",              "title": "Paste Image",               "category": "Markdown Foundry" }
+      { "command": "markdownFoundry.pasteImage",              "title": "Paste Image",               "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleBold",              "title": "Toggle Bold",               "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleItalic",            "title": "Toggle Italic",             "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleBoldItalic",        "title": "Toggle Bold+Italic",        "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleStrikethrough",     "title": "Toggle Strikethrough",      "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleBlockquote",        "title": "Toggle Blockquote",         "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleBlockCode",         "title": "Toggle Block Code",         "category": "Markdown Foundry" }
     ],
     "keybindings": [
       {
@@ -82,6 +88,18 @@
         "key": "ctrl+alt+v",
         "mac": "cmd+alt+v",
         "when": "editorTextFocus && editorLangId == markdown"
+      },
+      {
+        "command": "markdownFoundry.toggleBold",
+        "key": "ctrl+b",
+        "mac": "cmd+b",
+        "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
+      },
+      {
+        "command": "markdownFoundry.toggleItalic",
+        "key": "ctrl+i",
+        "mac": "cmd+i",
+        "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,14 @@ import { sortByColumnCommand } from './table/commands/sort';
 import { convertSelectionToTableCommand } from './table/commands/convert';
 import { pasteLinkCommand } from './insert/link';
 import { pasteImageCommand } from './insert/image';
+import {
+  toggleBoldCommand,
+  toggleItalicCommand,
+  toggleBoldItalicCommand,
+  toggleStrikethroughCommand,
+  toggleBlockquoteCommand,
+  toggleBlockCodeCommand
+} from './format/commands';
 import { registerInTableContext } from './util/contextKey';
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -51,6 +59,14 @@ export function activate(context: vscode.ExtensionContext): void {
   // Insertion
   register('markdownFoundry.pasteLink',  pasteLinkCommand);
   register('markdownFoundry.pasteImage', pasteImageCommand);
+
+  // Formatting toggles
+  register('markdownFoundry.toggleBold',          toggleBoldCommand);
+  register('markdownFoundry.toggleItalic',        toggleItalicCommand);
+  register('markdownFoundry.toggleBoldItalic',    toggleBoldItalicCommand);
+  register('markdownFoundry.toggleStrikethrough', toggleStrikethroughCommand);
+  register('markdownFoundry.toggleBlockquote',    toggleBlockquoteCommand);
+  register('markdownFoundry.toggleBlockCode',     toggleBlockCodeCommand);
 
   // Context key for Tab/Shift-Tab/Enter bindings
   registerInTableContext(context);

--- a/src/format/commands.ts
+++ b/src/format/commands.ts
@@ -1,0 +1,72 @@
+import * as vscode from 'vscode';
+import { wrapInline, wrapFenced, wrapLinePrefix } from './toggle';
+
+/**
+ * Apply an inline wrap to the current selection. If no selection, insert
+ * doubled markers at the cursor and place the cursor between them.
+ */
+async function applyInline(marker: string): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return;
+  const selection = editor.selection;
+
+  if (selection.isEmpty) {
+    const doubled = marker + marker;
+    const insertPos = selection.active;
+    await editor.edit((edit) => edit.insert(insertPos, doubled));
+    const newPos = insertPos.translate(0, marker.length);
+    editor.selection = new vscode.Selection(newPos, newPos);
+    return;
+  }
+
+  const text = editor.document.getText(selection);
+  const replaced = wrapInline(text, marker);
+  await editor.edit((edit) => edit.replace(selection, replaced));
+}
+
+export async function toggleBoldCommand(): Promise<void> {
+  await applyInline('**');
+}
+
+export async function toggleItalicCommand(): Promise<void> {
+  await applyInline('*');
+}
+
+export async function toggleBoldItalicCommand(): Promise<void> {
+  await applyInline('***');
+}
+
+export async function toggleStrikethroughCommand(): Promise<void> {
+  await applyInline('~~');
+}
+
+/**
+ * Expand the selection to cover full lines, then apply a transform to the
+ * resulting text block. Used by line-oriented toggles (blockquote, block code)
+ * so a cursor anywhere on a line operates on the whole line.
+ */
+async function applyLineRange(
+  transform: (text: string) => string
+): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return;
+  const selection = editor.selection;
+
+  const startLine = selection.start.line;
+  const endLine = selection.end.line;
+  const lineRange = new vscode.Range(
+    new vscode.Position(startLine, 0),
+    new vscode.Position(endLine, editor.document.lineAt(endLine).text.length)
+  );
+  const text = editor.document.getText(lineRange);
+  const replaced = transform(text);
+  await editor.edit((edit) => edit.replace(lineRange, replaced));
+}
+
+export async function toggleBlockquoteCommand(): Promise<void> {
+  await applyLineRange((text) => wrapLinePrefix(text, '> '));
+}
+
+export async function toggleBlockCodeCommand(): Promise<void> {
+  await applyLineRange((text) => wrapFenced(text));
+}

--- a/src/format/toggle.ts
+++ b/src/format/toggle.ts
@@ -1,0 +1,50 @@
+/**
+ * Toggle an inline wrap around text. If `text` already begins AND ends with
+ * `marker` (and is long enough to contain two copies of it), strips the
+ * marker; otherwise wraps. The length guard prevents `wrapInline("*", "**")`
+ * from falsely unwrapping a single `*`.
+ */
+export function wrapInline(text: string, marker: string): string {
+  if (
+    text.startsWith(marker) &&
+    text.endsWith(marker) &&
+    text.length >= marker.length * 2
+  ) {
+    return text.slice(marker.length, text.length - marker.length);
+  }
+  return marker + text + marker;
+}
+
+/**
+ * Toggle a triple-backtick fenced code block around text. Wraps with fences on
+ * their own lines; unwraps if the input is already a single fenced block.
+ */
+export function wrapFenced(text: string): string {
+  const FENCE = '```';
+  const lines = text.split(/\r?\n/);
+  const isFenced =
+    lines.length >= 2 &&
+    lines[0].startsWith(FENCE) &&
+    lines[lines.length - 1].trim() === FENCE;
+  if (isFenced) {
+    return lines.slice(1, -1).join('\n');
+  }
+  return `${FENCE}\n${text}\n${FENCE}`;
+}
+
+/**
+ * Toggle a line prefix (e.g. `"> "` for blockquote) on every non-empty line.
+ * If every non-empty line already starts with the prefix, removes it;
+ * otherwise prefixes every non-empty line. Empty lines are preserved as-is.
+ */
+export function wrapLinePrefix(text: string, prefix: string): string {
+  const lines = text.split(/\r?\n/);
+  const allPrefixed = lines.every((l) => l === '' || l.startsWith(prefix));
+
+  if (allPrefixed) {
+    return lines
+      .map((l) => (l.startsWith(prefix) ? l.slice(prefix.length) : l))
+      .join('\n');
+  }
+  return lines.map((l) => (l === '' ? l : prefix + l)).join('\n');
+}

--- a/src/test/suite/toggle.test.ts
+++ b/src/test/suite/toggle.test.ts
@@ -1,0 +1,99 @@
+import * as assert from 'assert';
+import { wrapInline, wrapFenced, wrapLinePrefix } from '../../format/toggle';
+
+suite('format: wrapInline', () => {
+  test('wraps plain text with the marker', () => {
+    assert.strictEqual(wrapInline('hello', '**'), '**hello**');
+  });
+
+  test('unwraps text that is already wrapped', () => {
+    assert.strictEqual(wrapInline('**hello**', '**'), 'hello');
+  });
+
+  test('does not falsely unwrap a single asterisk when marker is two', () => {
+    // `*` is 1 char; `**` would require at least 4 chars to safely contain both ends.
+    assert.strictEqual(wrapInline('*', '**'), '***');
+  });
+
+  test('wraps empty string with doubled markers', () => {
+    assert.strictEqual(wrapInline('', '**'), '****');
+  });
+
+  test('strikethrough round-trips', () => {
+    assert.strictEqual(wrapInline('text', '~~'), '~~text~~');
+    assert.strictEqual(wrapInline('~~text~~', '~~'), 'text');
+  });
+
+  test('bold+italic (triple marker) round-trips', () => {
+    assert.strictEqual(wrapInline('text', '***'), '***text***');
+    assert.strictEqual(wrapInline('***text***', '***'), 'text');
+  });
+});
+
+suite('format: wrapFenced', () => {
+  test('wraps a single-line block with fences on their own lines', () => {
+    assert.strictEqual(wrapFenced('print("hi")'), '```\nprint("hi")\n```');
+  });
+
+  test('wraps a multi-line block', () => {
+    const input = 'line1\nline2\nline3';
+    assert.strictEqual(wrapFenced(input), '```\nline1\nline2\nline3\n```');
+  });
+
+  test('unwraps an already-fenced block', () => {
+    const input = '```\nprint("hi")\n```';
+    assert.strictEqual(wrapFenced(input), 'print("hi")');
+  });
+
+  test('unwraps a fenced block with a language hint on the opening fence', () => {
+    // Opening fence starts with ```, the language hint `ts` is part of the same line.
+    const input = '```ts\nconst x = 1;\n```';
+    assert.strictEqual(wrapFenced(input), 'const x = 1;');
+  });
+
+  test('wraps an empty string', () => {
+    assert.strictEqual(wrapFenced(''), '```\n\n```');
+  });
+});
+
+suite('format: wrapLinePrefix', () => {
+  test('prefixes every non-empty line with the prefix', () => {
+    const input = 'line1\nline2\nline3';
+    assert.strictEqual(
+      wrapLinePrefix(input, '> '),
+      '> line1\n> line2\n> line3'
+    );
+  });
+
+  test('unprefixes every line when all non-empty lines are prefixed', () => {
+    const input = '> line1\n> line2\n> line3';
+    assert.strictEqual(wrapLinePrefix(input, '> '), 'line1\nline2\nline3');
+  });
+
+  test('empty lines pass through the wrap path unchanged', () => {
+    const input = 'first\n\nthird';
+    assert.strictEqual(
+      wrapLinePrefix(input, '> '),
+      '> first\n\n> third'
+    );
+  });
+
+  test('empty lines pass through the unwrap path unchanged', () => {
+    const input = '> first\n\n> third';
+    assert.strictEqual(
+      wrapLinePrefix(input, '> '),
+      'first\n\nthird'
+    );
+  });
+
+  test('mixed prefix state forces the wrap path (adds prefix everywhere)', () => {
+    // One line prefixed, one not → not all prefixed → add prefix to every line.
+    // The already-prefixed line picks up a second prefix (nested quote).
+    const input = '> already\nnew';
+    assert.strictEqual(wrapLinePrefix(input, '> '), '> > already\n> new');
+  });
+
+  test('empty string stays empty', () => {
+    assert.strictEqual(wrapLinePrefix('', '> '), '');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 6 formatting toggle commands: `toggleBold`, `toggleItalic`, `toggleBoldItalic`, `toggleStrikethrough`, `toggleBlockquote`, `toggleBlockCode`.
- Inline commands (bold/italic/bold+italic/strikethrough) wrap the selection or insert doubled markers at the cursor on empty selection, centered.
- Line-oriented commands (blockquote, block code) expand to full-line ranges before applying the transform.
- Two new keybindings: `Ctrl/Cmd+B` (bold) and `Ctrl/Cmd+I` (italic), scoped to markdown editors. Other 4 commands are palette-only.
- New module `src/format/` split pure/impure: `toggle.ts` contains the three pure helpers (no `vscode` imports), `commands.ts` has the editor-touching adapters.

## Verification

- [x] 6 commands registered in `src/extension.ts` and declared in `package.json` with correct titles and category
- [x] Keybindings on `toggleBold` and `toggleItalic` only; `when` clause is `editorTextFocus && editorLangId == markdown && !suggestWidgetVisible` (no `inTable` gate — these work anywhere in markdown)
- [x] Inline wrap/unwrap: round-trips for `**`/`*`/`***`/`~~`; short-input guard (`wrapInline("*", "**")` returns `"***"` not `"*"`)
- [x] Empty-selection insert: doubled markers + cursor centered between them via `editor.selection = new vscode.Selection(newPos, newPos)` after `translate(0, marker.length)`
- [x] Blockquote: all non-empty prefixed → unwrap; otherwise wrap every non-empty line; empty lines pass through
- [x] Block code: single-line + multi-line wrap; unwrap existing fenced block including with language hint (` ```ts `)
- [x] `src/format/toggle.ts` is pure — 0 `vscode` imports (verified via grep)
- [x] 6-file test suite in `src/test/suite/toggle.test.ts`: wrap/unwrap per marker, edge cases, multi-line, mixed-prefix blockquote
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [ ] Manual smoke test in dev host: select `hello` → `Ctrl+B` → `**hello**` → `Ctrl+B` → `hello`. Palette-run each of the 4 non-keybinding commands against a test selection.

## Ctrl+B keybinding conflict

`Ctrl+B` defaults to "Toggle Sidebar Visibility" in VS Code. The `when` clause scopes our binding to markdown-focused editors, so sidebar toggle still works when focus is elsewhere. Accepted tradeoff: Markdown bold is universally expected on `Ctrl+B` across markdown editors, and the sidebar toggle remains one click away.

## CHANGELOG compliance

User-visible feature — `### Added` bullet appended under `## [Unreleased]` linking to this PR (#58). `[Unreleased]` running total: 2 `### Added` entries (formatting toggles + multi-line CSV), 3 `### Changed` entries (Tab selects cell, string-width, README).

Closes #19