### PR TITLE
Update README for formatting toggles (features list + keybindings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Changed
 
+- README Features list gains a Formatting subsection describing the new bold / italic / blockquote / block code / strikethrough toggles; Keybindings table lists `Ctrl/Cmd+B` and `Ctrl/Cmd+I` ([#60](https://github.com/dvlprlife/Markdown-Foundry/pull/60)).
 - Tab, Shift+Tab, and Enter navigation inside a table now selects the destination cell's contents (Excel-style) so typing replaces the cell, and another Tab advances to the next cell instead of inserting a literal tab character. Empty cells still get a collapsed cursor position ([#57](https://github.com/dvlprlife/Markdown-Foundry/pull/57)).
 - Table column alignment now uses the `string-width` library for width calculation, correctly handling ZWJ emoji sequences (e.g. 👨‍👩‍👧‍👦), combining marks, variation selectors, and the full East Asian Width table — previously a hand-rolled approximation under-counted width in some Unicode cases ([#53](https://github.com/dvlprlife/Markdown-Foundry/pull/53)).
 - README Paste Image description updated: drops the stale "Windows only" note (macOS and Linux both shipped in 0.2.0) and adds a Linux dependency note for `xclip` / `wl-clipboard` ([#55](https://github.com/dvlprlife/Markdown-Foundry/pull/55)).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Markdown Foundry makes working with tables fast and ergonomic — align columns,
 - **Paste Link** — If the clipboard contains a URL, wrap the selection (or prompt for text) and insert `[text](url)`.
 - **Paste Image** — Save the clipboard image to a configurable folder and insert a Markdown image reference. On Linux, requires `xclip` (X11) or `wl-clipboard` (Wayland) to be installed.
 
+### Formatting
+
+- **Toggle bold / italic / bold+italic / strikethrough** — wrap a selection with the Markdown marker; re-invoke to unwrap. With no selection, inserts the doubled markers with the cursor between them.
+- **Toggle blockquote** — prefix every non-empty line in the selection with `> `; re-invoke to strip the prefix.
+- **Toggle block code** — wrap the selection with fenced ` ``` ` lines; re-invoke to remove the fence.
+
 ## Keybindings
 
 | Shortcut | Command |
@@ -38,6 +44,8 @@ Markdown Foundry makes working with tables fast and ergonomic — align columns,
 | `Enter` | Next row (when inside a table) |
 | `Ctrl+Shift+T` / `Cmd+Shift+T` | Align table |
 | `Ctrl+Alt+V` / `Cmd+Alt+V` | Paste image |
+| `Ctrl+B` / `Cmd+B` | Toggle bold (when editing a Markdown file) |
+| `Ctrl+I` / `Cmd+I` | Toggle italic (when editing a Markdown file) |
 
 All other commands are available through the Command Palette (search for "Markdown Foundry").
 


### PR DESCRIPTION
## Summary

- Adds `### Formatting` subsection under `## Features` describing the 6 toggles from PR #58.
- Adds 2 rows to the Keybindings table: `Ctrl/Cmd+B` (toggleBold) and `Ctrl/Cmd+I` (toggleItalic) with "(when editing a Markdown file)" scope qualifier.
- Adds a `### Changed` bullet under `[Unreleased]` in CHANGELOG.

## Verification

- [x] `README.md` Features now has 3 subsections in order: Table editing, Insertion commands, Formatting
- [x] Keybindings table contains `Ctrl+B` and `Ctrl+I` rows (positioned after the existing 5 rows, grouped with other editor-wide bindings)
- [x] No other README sections touched
- [x] `CHANGELOG.md` `[Unreleased]` → `### Changed` now has 4 bullets; the new one references PR #60
- [x] `git diff --stat`: 2 files (`README.md`, `CHANGELOG.md`), 9 insertions
- [x] No source, package.json, LICENSE, icon, or agents/ touched
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)

## Ordering note

This PR was delayed briefly while waiting for #58 to merge first — the README here references commands that must exist on `main`, so this had to land after #58 to avoid leaving `main` in a temporarily inconsistent state (README mentioning commands that don't exist). #58 merged (commit `d55f72e`); this PR is then rebased on post-#58 `main`.

## CHANGELOG compliance

User-visible change — `### Changed` bullet appended under `## [Unreleased]`.

Closes #59