### PR TITLE
Codify README discipline for user-facing command additions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,35 @@ These are non-negotiable:
 - Rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` (use the actual publish date)
 - Add a fresh empty `## [Unreleased]` section above it for the next cycle
 
+## README maintenance
+
+`README.md` is the public face of the extension on the VS Code Marketplace listing. Any PR that introduces a **new user-discoverable command, setting, or keybinding** must include matching README updates in the same PR.
+
+**What counts as user-discoverable** (README update required):
+
+- New commands accessible via the Command Palette
+- New keybindings (or removed keybindings)
+- New configuration settings users can change
+- Behavior changes to documented features that make the existing README description inaccurate
+- Removed commands, settings, or keybindings — strip them from the README
+
+**What does NOT count** (no README update needed):
+
+- Internal refactors, helper extraction, namespace renames where the user-visible commands stay the same
+- Test-only changes
+- Bug fixes that restore documented behavior
+- Marketplace metadata only (`keywords`, `categories` — those go in CHANGELOG, not README)
+- Build, CI, `.gitignore` / `.vscodeignore` updates
+- Contributor-facing docs (`CLAUDE.md`, `agents/**`, `CONTEXT.md`)
+
+**Where to update:**
+
+- New commands: add a bullet under the appropriate `## Features` subsection (Table editing / Insertion commands / Formatting). Create a new subsection if the command doesn't fit.
+- New keybindings: add a row to the `## Keybindings` table.
+- New settings: add a row to the `## Settings` table.
+
+README accumulates incrementally; there's no release-time rollover. README always describes the current state of `main`.
+
 ## Code style
 
 - **Default to no comments.** Only add a comment when the WHY is non-obvious (a hidden constraint, a workaround, behavior that would surprise a reader). Never explain WHAT — well-named identifiers do that.

--- a/agents/issue-worker.md
+++ b/agents/issue-worker.md
@@ -61,6 +61,8 @@ Make all necessary changes to satisfy the acceptance criteria. Follow all rules 
 
 **CHANGELOG:** if the change is user-visible (per the classification in `CLAUDE.md` → CHANGELOG maintenance), add a one-line entry under `## [Unreleased]` in `CHANGELOG.md` as part of the same PR. Not a separate commit; bundle it with the implementation. If the change is contributor-facing only, skip the entry and note the reason in the PR body so the reviewer doesn't flag it.
 
+**README:** if the change introduces a new user-discoverable command, setting, or keybinding (per `CLAUDE.md` → README maintenance), update `README.md` in the same PR — Features list, Keybindings table, or Settings table as appropriate. Bundle the README change with the implementation, not as a separate commit. If the change is internal-only, skip the update and note the reason in the PR body so the reviewer doesn't flag it.
+
 ## Step 6: Commit and Push
 
 Commit with a message that references the issue:

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -40,13 +40,14 @@ From the issue, extract:
 - The issue body (especially Acceptance Criteria)
 - The `## Implementation Plan` comment posted by the issue planner
 
-## Step 4: Review Against Five Criteria
+## Step 4: Review Against Six Criteria
 
 1. **Implementation Plan adherence** — does the diff match the file-by-file changes described in the plan comment?
 2. **Acceptance Criteria** — is each acceptance criterion in the issue body satisfied by the diff?
 3. **Code quality** — bugs, missing edge cases, security issues, dead code, obvious style problems.
 4. **CLAUDE.md compliance** — commit messages reference the issue, branch is named `issue-{number}-*`, TypeScript strict-mode rules upheld (no `any`, no unused locals, all returns explicit), project conventions in `CLAUDE.md` respected (locator/parser/formatter layering, forward-slash paths in inserted Markdown, stubs fail loudly rather than silently), no other violations of documented conventions.
 5. **CHANGELOG compliance** — if the PR introduces a user-visible change (new command, changed behavior, fixed bug, marketplace metadata affecting the listing), the diff must include an entry under `## [Unreleased]` in `CHANGELOG.md`. If the PR is contributor-facing only (tests, CI, `agents/`, internal docs) or a pure refactor, no entry is required — but note the skip in the review so it's a conscious choice, not an oversight.
+6. **README compliance** — if the PR introduces a new user-discoverable command, setting, or keybinding (per `CLAUDE.md` → README maintenance), the diff must include matching `README.md` updates. If the PR is contributor-facing only, internal refactor, bug fix, or metadata-only, no README update is required — but note the skip in the review so it's a conscious choice, not an oversight.
 
 ## Step 5: Post Review on the PR
 


### PR DESCRIPTION
## Summary

- Adds a `## README maintenance` section to `CLAUDE.md` (after `## CHANGELOG maintenance`) classifying when README updates are required vs skipped.
- Adds a 6th review criterion ("README compliance") to `agents/pr-reviewer.md`; updates Step 4 heading from "Five" to "Six".
- Extends `agents/issue-worker.md` Step 5 with a parallel README reminder alongside the existing CHANGELOG one.

3 files, 33 insertions / 1 deletion (the single deletion is the Step 4 heading change).

## CHANGELOG and README compliance — both skip with reason

This PR is **contributor-facing only** — modifies rules documentation (`CLAUDE.md`) and agent workflow files (`agents/*.md`), with zero impact on user-discoverable commands, settings, or keybindings.

- **CHANGELOG skip**: contributor-facing per criterion 5 classification (no `[Unreleased]` entry needed)
- **README skip** (under the new criterion 6 being introduced): contributor-facing, no user-discoverable surface added

The reviewer should evaluate this PR under the new 6-criterion rubric — same recursive pattern PR #45 used when adding criterion 5. Both skips above are explicit and intentional.

## Verification

- [x] `CLAUDE.md` has a `## README maintenance` section placed after `## CHANGELOG maintenance` covering the classification rules
- [x] `agents/pr-reviewer.md` Step 4 heading reads "Review Against Six Criteria"; criterion 6 named "README compliance" is present
- [x] `agents/issue-worker.md` Step 5 includes a `**README:**` paragraph after the existing `**CHANGELOG:**` paragraph
- [x] `git diff --stat`: exactly 3 files modified
- [x] `Grep "Five Criteria" agents/pr-reviewer.md` returns 0 matches (heading was correctly updated)
- [x] No source, README, or `package.json` modified
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)

Closes #63