### PR TITLE
Add formatting toggles v2 (inline code, headings, task list, horizontal rule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Added
 
+- Formatting toggles (round 2): inline code, heading levels 1–6, promote/demote heading, task list checkbox cycle, and insert horizontal rule. Palette-only access; no default keybindings ([#65](https://github.com/dvlprlife/Markdown-Foundry/pull/65)).
 - Formatting toggles: bold (`Ctrl/Cmd+B`), italic (`Ctrl/Cmd+I`), bold+italic, blockquote, block code (fenced), strikethrough. Wrap the selection or insert empty markers at the cursor ([#58](https://github.com/dvlprlife/Markdown-Foundry/pull/58)).
 - `Convert Selection to Table` now handles CSV data with multi-line quoted fields — embedded newlines become `<br>` so the resulting Markdown table cell renders on one line while preserving the line break visually ([#56](https://github.com/dvlprlife/Markdown-Foundry/pull/56)).
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Markdown Foundry makes working with tables fast and ergonomic — align columns,
 - **Toggle bold / italic / bold+italic / strikethrough** — wrap a selection with the Markdown marker; re-invoke to unwrap. With no selection, inserts the doubled markers with the cursor between them.
 - **Toggle blockquote** — prefix every non-empty line in the selection with `> `; re-invoke to strip the prefix.
 - **Toggle block code** — wrap the selection with fenced ` ``` ` lines; re-invoke to remove the fence.
+- **Toggle inline code** — wrap the selection with single backticks; re-invoke to unwrap.
+- **Toggle heading levels 1–6** — set the current line to the chosen heading level, or remove the heading if it's already at that level. Plus **Promote / Demote heading** to shift the existing level by one (clamped to H1–H6).
+- **Toggle task list item** — cycle the current line through plain → `- [ ] todo` → `- [x] done` → `- [ ] todo` …, preserving leading indentation.
+- **Insert horizontal rule** — drop a `---` line below the cursor's current line.
 
 ## Keybindings
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,18 @@
       { "command": "markdownFoundry.toggleBoldItalic",        "title": "Toggle Bold+Italic",        "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleStrikethrough",     "title": "Toggle Strikethrough",      "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleBlockquote",        "title": "Toggle Blockquote",         "category": "Markdown Foundry" },
-      { "command": "markdownFoundry.toggleBlockCode",         "title": "Toggle Block Code",         "category": "Markdown Foundry" }
+      { "command": "markdownFoundry.toggleBlockCode",         "title": "Toggle Block Code",         "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleInlineCode",        "title": "Toggle Inline Code",        "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleHeading1",          "title": "Toggle Heading 1",          "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleHeading2",          "title": "Toggle Heading 2",          "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleHeading3",          "title": "Toggle Heading 3",          "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleHeading4",          "title": "Toggle Heading 4",          "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleHeading5",          "title": "Toggle Heading 5",          "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleHeading6",          "title": "Toggle Heading 6",          "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.promoteHeading",          "title": "Promote Heading",           "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.demoteHeading",           "title": "Demote Heading",            "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleTaskList",          "title": "Toggle Task List Item",     "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.insertHorizontalRule",    "title": "Insert Horizontal Rule",    "category": "Markdown Foundry" }
     ],
     "keybindings": [
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,18 @@ import {
   toggleBoldItalicCommand,
   toggleStrikethroughCommand,
   toggleBlockquoteCommand,
-  toggleBlockCodeCommand
+  toggleBlockCodeCommand,
+  toggleInlineCodeCommand,
+  toggleHeading1Command,
+  toggleHeading2Command,
+  toggleHeading3Command,
+  toggleHeading4Command,
+  toggleHeading5Command,
+  toggleHeading6Command,
+  promoteHeadingCommand,
+  demoteHeadingCommand,
+  toggleTaskListCommand,
+  insertHorizontalRuleCommand
 } from './format/commands';
 import { registerInTableContext } from './util/contextKey';
 
@@ -67,6 +78,17 @@ export function activate(context: vscode.ExtensionContext): void {
   register('markdownFoundry.toggleStrikethrough', toggleStrikethroughCommand);
   register('markdownFoundry.toggleBlockquote',    toggleBlockquoteCommand);
   register('markdownFoundry.toggleBlockCode',     toggleBlockCodeCommand);
+  register('markdownFoundry.toggleInlineCode',    toggleInlineCodeCommand);
+  register('markdownFoundry.toggleHeading1',      toggleHeading1Command);
+  register('markdownFoundry.toggleHeading2',      toggleHeading2Command);
+  register('markdownFoundry.toggleHeading3',      toggleHeading3Command);
+  register('markdownFoundry.toggleHeading4',      toggleHeading4Command);
+  register('markdownFoundry.toggleHeading5',      toggleHeading5Command);
+  register('markdownFoundry.toggleHeading6',      toggleHeading6Command);
+  register('markdownFoundry.promoteHeading',      promoteHeadingCommand);
+  register('markdownFoundry.demoteHeading',       demoteHeadingCommand);
+  register('markdownFoundry.toggleTaskList',      toggleTaskListCommand);
+  register('markdownFoundry.insertHorizontalRule', insertHorizontalRuleCommand);
 
   // Context key for Tab/Shift-Tab/Enter bindings
   registerInTableContext(context);

--- a/src/format/commands.ts
+++ b/src/format/commands.ts
@@ -1,5 +1,12 @@
 import * as vscode from 'vscode';
-import { wrapInline, wrapFenced, wrapLinePrefix } from './toggle';
+import {
+  wrapInline,
+  wrapFenced,
+  wrapLinePrefix,
+  wrapHeading,
+  adjustHeading,
+  toggleTaskItem
+} from './toggle';
 
 /**
  * Apply an inline wrap to the current selection. If no selection, insert
@@ -69,4 +76,69 @@ export async function toggleBlockquoteCommand(): Promise<void> {
 
 export async function toggleBlockCodeCommand(): Promise<void> {
   await applyLineRange((text) => wrapFenced(text));
+}
+
+/**
+ * Apply a line-aware transform to the cursor's current line, replacing only
+ * that line. Used by heading toggles, task list, etc. — operations where the
+ * single-line semantics differ from `applyLineRange`'s multi-line block.
+ */
+async function applyCurrentLine(
+  transform: (line: string) => string
+): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return;
+  const cursorLine = editor.selection.active.line;
+  const line = editor.document.lineAt(cursorLine);
+  const replaced = transform(line.text);
+  await editor.edit((edit) => edit.replace(line.range, replaced));
+}
+
+export async function toggleInlineCodeCommand(): Promise<void> {
+  await applyInline('`');
+}
+
+export async function toggleHeading1Command(): Promise<void> {
+  await applyCurrentLine((line) => wrapHeading(line, 1));
+}
+
+export async function toggleHeading2Command(): Promise<void> {
+  await applyCurrentLine((line) => wrapHeading(line, 2));
+}
+
+export async function toggleHeading3Command(): Promise<void> {
+  await applyCurrentLine((line) => wrapHeading(line, 3));
+}
+
+export async function toggleHeading4Command(): Promise<void> {
+  await applyCurrentLine((line) => wrapHeading(line, 4));
+}
+
+export async function toggleHeading5Command(): Promise<void> {
+  await applyCurrentLine((line) => wrapHeading(line, 5));
+}
+
+export async function toggleHeading6Command(): Promise<void> {
+  await applyCurrentLine((line) => wrapHeading(line, 6));
+}
+
+export async function promoteHeadingCommand(): Promise<void> {
+  await applyCurrentLine((line) => adjustHeading(line, -1));
+}
+
+export async function demoteHeadingCommand(): Promise<void> {
+  await applyCurrentLine((line) => adjustHeading(line, 1));
+}
+
+export async function toggleTaskListCommand(): Promise<void> {
+  await applyCurrentLine(toggleTaskItem);
+}
+
+export async function insertHorizontalRuleCommand(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return;
+  const cursorLine = editor.selection.active.line;
+  const line = editor.document.lineAt(cursorLine);
+  const insertPos = new vscode.Position(cursorLine, line.text.length);
+  await editor.edit((edit) => edit.insert(insertPos, '\n---'));
 }

--- a/src/format/toggle.ts
+++ b/src/format/toggle.ts
@@ -48,3 +48,53 @@ export function wrapLinePrefix(text: string, prefix: string): string {
   }
   return lines.map((l) => (l === '' ? l : prefix + l)).join('\n');
 }
+
+/**
+ * Set the heading level of a line. `level === 0` removes the heading. If the
+ * line is already at the target level, also removes the heading (toggle off).
+ * Strips leading whitespace from the body when adding a heading.
+ */
+export function wrapHeading(line: string, level: number): string {
+  const existing = line.match(/^(#{1,6})\s+(.*)$/);
+  const body = existing ? existing[2] : line.replace(/^\s+/, '');
+  const existingLevel = existing ? existing[1].length : 0;
+
+  if (level === 0 || level === existingLevel) {
+    return body;
+  }
+  return '#'.repeat(level) + ' ' + body;
+}
+
+/**
+ * Adjust an existing heading by `delta` (negative = promote toward H1,
+ * positive = demote toward H6). No-op on non-heading lines or if the
+ * adjustment would push the level outside [1, 6].
+ */
+export function adjustHeading(line: string, delta: number): string {
+  const m = line.match(/^(#{1,6})\s+(.*)$/);
+  if (!m) return line;
+  const newLevel = m[1].length + delta;
+  if (newLevel < 1 || newLevel > 6) return line;
+  return '#'.repeat(newLevel) + ' ' + m[2];
+}
+
+/**
+ * Cycle a line through: plain → `- [ ] x` → `- [x] x` → `- [ ] x` → ... .
+ * Preserves leading indentation. A bullet line without a checkbox (`- x`) is
+ * promoted to an unchecked task (`- [ ] x`).
+ */
+export function toggleTaskItem(line: string): string {
+  const indentMatch = line.match(/^(\s*)(.*)$/);
+  const indent = indentMatch ? indentMatch[1] : '';
+  const body = indentMatch ? indentMatch[2] : line;
+
+  const checked = body.match(/^-\s+\[x\]\s+(.*)$/i);
+  if (checked) return `${indent}- [ ] ${checked[1]}`;
+
+  const unchecked = body.match(/^-\s+\[ \]\s+(.*)$/);
+  if (unchecked) return `${indent}- [x] ${unchecked[1]}`;
+
+  const bullet = body.match(/^-\s+(.*)$/);
+  const text = bullet ? bullet[1] : body;
+  return `${indent}- [ ] ${text}`;
+}

--- a/src/test/suite/toggle.test.ts
+++ b/src/test/suite/toggle.test.ts
@@ -1,5 +1,12 @@
 import * as assert from 'assert';
-import { wrapInline, wrapFenced, wrapLinePrefix } from '../../format/toggle';
+import {
+  wrapInline,
+  wrapFenced,
+  wrapLinePrefix,
+  wrapHeading,
+  adjustHeading,
+  toggleTaskItem
+} from '../../format/toggle';
 
 suite('format: wrapInline', () => {
   test('wraps plain text with the marker', () => {
@@ -95,5 +102,89 @@ suite('format: wrapLinePrefix', () => {
 
   test('empty string stays empty', () => {
     assert.strictEqual(wrapLinePrefix('', '> '), '');
+  });
+});
+
+suite('format: wrapHeading', () => {
+  test('adds heading at the requested level on a plain line', () => {
+    assert.strictEqual(wrapHeading('Some text', 2), '## Some text');
+  });
+
+  test('toggles off when applied at the existing level', () => {
+    assert.strictEqual(wrapHeading('## Some text', 2), 'Some text');
+  });
+
+  test('changes level when applied at a different existing level', () => {
+    assert.strictEqual(wrapHeading('# Some text', 3), '### Some text');
+  });
+
+  test('strips leading whitespace from a non-heading line when adding a heading', () => {
+    assert.strictEqual(wrapHeading('   leading spaces', 1), '# leading spaces');
+  });
+
+  test('level 0 removes any heading', () => {
+    assert.strictEqual(wrapHeading('### Demoted', 0), 'Demoted');
+  });
+
+  test('level 0 on a non-heading line is effectively a leading-trim', () => {
+    assert.strictEqual(wrapHeading('plain', 0), 'plain');
+  });
+
+  test('empty input', () => {
+    assert.strictEqual(wrapHeading('', 1), '# ');
+  });
+});
+
+suite('format: adjustHeading', () => {
+  test('promotes H2 to H1', () => {
+    assert.strictEqual(adjustHeading('## hi', -1), '# hi');
+  });
+
+  test('demotes H1 to H2', () => {
+    assert.strictEqual(adjustHeading('# hi', 1), '## hi');
+  });
+
+  test('clamps at H1 (promote no-op)', () => {
+    assert.strictEqual(adjustHeading('# hi', -1), '# hi');
+  });
+
+  test('clamps at H6 (demote no-op)', () => {
+    assert.strictEqual(adjustHeading('###### hi', 1), '###### hi');
+  });
+
+  test('non-heading line is no-op', () => {
+    assert.strictEqual(adjustHeading('plain text', -1), 'plain text');
+    assert.strictEqual(adjustHeading('plain text', 1), 'plain text');
+  });
+
+  test('empty input is no-op', () => {
+    assert.strictEqual(adjustHeading('', -1), '');
+  });
+});
+
+suite('format: toggleTaskItem', () => {
+  test('plain text becomes an unchecked task item', () => {
+    assert.strictEqual(toggleTaskItem('do laundry'), '- [ ] do laundry');
+  });
+
+  test('unchecked task item becomes checked', () => {
+    assert.strictEqual(toggleTaskItem('- [ ] do laundry'), '- [x] do laundry');
+  });
+
+  test('checked task item becomes unchecked', () => {
+    assert.strictEqual(toggleTaskItem('- [x] do laundry'), '- [ ] do laundry');
+  });
+
+  test('plain bullet without checkbox becomes an unchecked task', () => {
+    assert.strictEqual(toggleTaskItem('- bullet'), '- [ ] bullet');
+  });
+
+  test('preserves leading indentation when wrapping', () => {
+    assert.strictEqual(toggleTaskItem('  do laundry'), '  - [ ] do laundry');
+  });
+
+  test('preserves leading indentation when toggling check state', () => {
+    assert.strictEqual(toggleTaskItem('  - [ ] do laundry'), '  - [x] do laundry');
+    assert.strictEqual(toggleTaskItem('  - [x] do laundry'), '  - [ ] do laundry');
   });
 });


### PR DESCRIPTION
## Summary

- Adds 11 new commands: `toggleInlineCode`, `toggleHeading1`–`toggleHeading6`, `promoteHeading`, `demoteHeading`, `toggleTaskList`, `insertHorizontalRule`.
- Three new pure helpers in `src/format/toggle.ts`: `wrapHeading`, `adjustHeading`, `toggleTaskItem`.
- New `applyCurrentLine` adapter in `src/format/commands.ts` for line-aware transforms (headings, task list, promote/demote). Horizontal rule has its own adapter that appends `\n---` after the cursor's line.
- Palette-only — no default keybindings (Ctrl+Shift+1–6 and Ctrl+Shift+]/[ conflict with VS Code defaults).
- README and CHANGELOG updated per the new discipline rules from PRs #45 and #64.

## Verification

- [x] 11 commands registered in `src/extension.ts` (verified via grep)
- [x] 11 entries declared in `package.json` `contributes.commands` with category `Markdown Foundry`
- [x] `toggleInlineCode` wraps selection in single backticks via shared `applyInline`
- [x] `toggleHeadingN` (N=1..6) sets/toggles-off the heading at level N
- [x] `promoteHeading` / `demoteHeading` clamp at H1/H6, no-op on non-heading lines (covered by tests)
- [x] `toggleTaskList` cycles plain → `- [ ]` → `- [x]` → `- [ ]`, preserves indentation (6 test cases)
- [x] `insertHorizontalRule` appends `\n---` after the cursor's current line
- [x] No default keybindings (palette-only, per the issue spec)
- [x] `src/format/toggle.ts` gains `wrapHeading`, `adjustHeading`, `toggleTaskItem` as pure helpers (no `vscode` runtime imports preserved)
- [x] 19 new unit tests in `src/test/suite/toggle.test.ts`
- [x] CHANGELOG `### Added` entry under `## [Unreleased]` with PR #65 link
- [x] README Formatting subsection extended with 4 new bullets covering the 11 commands
- [x] `npx tsc --noEmit` passes (exit 0)
- [x] `node esbuild.js --production` passes (exit 0)
- [ ] Manual smoke test in dev host: each of the 11 commands against a sample doc with mixed content (human-only)

## CHANGELOG and README compliance (under the new 6-criterion rubric)

User-visible feature — both rules apply, both satisfied:
- **CHANGELOG**: `### Added` entry appended under `## [Unreleased]`
- **README**: 4 new bullets appended under `### Formatting`

## `[Unreleased]` running total

After this merges, `[Unreleased]` accumulates: 3 `### Added` (formatting v2 ⬅, formatting v1 #58, multi-line CSV #56) + 4 `### Changed` (README formatting #60, Tab selects cell #57, string-width #53, README paste-image #55). Substantive batch — likely warrants a `0.3.0` minor bump on next release housekeeping.

Closes #52