### PR TITLE
Bump to v0.3.0 and roll over changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-25
+
 ### Added
 
 - Formatting toggles (round 2): inline code, heading levels 1–6, promote/demote heading, task list checkbox cycle, and insert horizontal rule. Palette-only access; no default keybindings ([#65](https://github.com/dvlprlife/Markdown-Foundry/pull/65)).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdfoundry",
   "displayName": "Markdown Foundry",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "publisher": "dvlprlife",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

- Bump `package.json` version `0.2.1` → `0.3.0`
- Roll over the `[Unreleased]` accumulator into a dated `## [0.3.0] - 2026-04-25` section in `CHANGELOG.md`

The new release captures 8 user-facing entries that landed since 0.2.1:

**Added**
- Formatting toggles round 2: inline code, headings 1–6, promote/demote, task list cycle, horizontal rule (#65)
- Formatting toggles round 1: bold, italic, bold+italic, blockquote, block code, strikethrough (#58)
- CSV-to-table now handles multi-line quoted fields via `<br>` (#56)

**Changed**
- Demo GIFs refreshed and expanded (palette overview, bold, headings, task list) — 7 GIFs at ~4.6 MB (#66)
- README Features list adds Formatting subsection; keybindings table lists `Ctrl/Cmd+B` and `Ctrl/Cmd+I` (#60)
- Tab/Shift+Tab/Enter now selects the destination cell's contents Excel-style (#57)
- Table column alignment uses `string-width` for correct Unicode/ZWJ/East-Asian width (#53)
- README Paste Image: drops stale "Windows only" note; adds Linux `xclip`/`wl-clipboard` requirement (#55)

Closes #67

## Test plan

- [x] `tsc --noEmit` passes
- [x] `node esbuild.js --production` passes
- [x] CHANGELOG section order: `[Unreleased]` → `[0.3.0] - 2026-04-25` → `[0.2.1]` → `[0.2.0]` → `[0.1.1]` → `[0.1.0]`
- [x] All 8 `[Unreleased]` entries preserved verbatim under the new dated heading
- [ ] After merge: `vsce package` produces `mdfoundry-0.3.0.vsix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)