### PR TITLE
add insert-table command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Added
+
+- `Insert Table` command — pick from preset sizes (2×2 through 5×4) or enter custom dimensions to insert a pre-aligned Markdown table at the cursor. Header cells default to `Column 1`, `Column 2`, … with the first cell selected for immediate editing. Palette-only ([#72](https://github.com/dvlprlife/Markdown-Foundry/pull/72)).
+
 ## [0.3.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Markdown Foundry combines fast table editing with one-keystroke Markdown formatt
 - **Move rows and columns** — Reorder without retyping.
 - **Sort by column** — Sort ascending or descending. Numeric columns are detected automatically.
 - **Convert selection to table** — Select pasted CSV or TSV data, run the command, get a formatted Markdown table.
+- **Insert Table** — Pick from preset sizes (2×2 through 5×4) or enter custom dimensions; a pre-aligned table is inserted at the cursor with the first header cell selected.
 
 ### Insertion commands
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
       { "command": "markdownFoundry.moveColumnRight",         "title": "Move Column Right",         "category": "Markdown Foundry" },
       { "command": "markdownFoundry.sortByColumn",            "title": "Sort Table by Column",      "category": "Markdown Foundry" },
       { "command": "markdownFoundry.convertSelectionToTable", "title": "Convert Selection to Table","category": "Markdown Foundry" },
+      { "command": "markdownFoundry.insertTable",             "title": "Insert Table",              "category": "Markdown Foundry" },
       { "command": "markdownFoundry.nextCell",                "title": "Next Cell",                 "category": "Markdown Foundry" },
       { "command": "markdownFoundry.previousCell",            "title": "Previous Cell",             "category": "Markdown Foundry" },
       { "command": "markdownFoundry.nextRow",                 "title": "Next Row",                  "category": "Markdown Foundry" },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import {
 } from './table/commands/navigate';
 import { sortByColumnCommand } from './table/commands/sort';
 import { convertSelectionToTableCommand } from './table/commands/convert';
+import { insertTableCommand } from './insert/insertTable';
 import { pasteLinkCommand } from './insert/link';
 import { pasteImageCommand } from './insert/image';
 import {
@@ -61,6 +62,7 @@ export function activate(context: vscode.ExtensionContext): void {
   register('markdownFoundry.moveColumnRight',         moveColumnRightCommand);
   register('markdownFoundry.sortByColumn',            sortByColumnCommand);
   register('markdownFoundry.convertSelectionToTable', convertSelectionToTableCommand);
+  register('markdownFoundry.insertTable',             insertTableCommand);
 
   // Navigation
   register('markdownFoundry.nextCell',     nextCellCommand);

--- a/src/insert/insertTable.ts
+++ b/src/insert/insertTable.ts
@@ -1,0 +1,161 @@
+import * as vscode from 'vscode';
+import { Alignment, TableModel } from '../table/types';
+import { formatTable } from '../table/formatter';
+
+interface PresetSize {
+  rows: number;
+  cols: number;
+}
+
+const PRESETS: readonly PresetSize[] = [
+  { rows: 2, cols: 2 },
+  { rows: 3, cols: 3 },
+  { rows: 3, cols: 2 },
+  { rows: 4, cols: 3 },
+  { rows: 5, cols: 3 },
+  { rows: 5, cols: 4 }
+];
+
+const FIRST_HEADER_LABEL = 'Column 1';
+
+const ROW_MIN = 1;
+const ROW_MAX = 50;
+const COL_MIN = 1;
+const COL_MAX = 20;
+
+export function buildEmptyTable(
+  rows: number,
+  cols: number,
+  alignment: Alignment,
+  eol: string
+): string {
+  const headers = Array.from({ length: cols }, (_, i) => `Column ${i + 1}`);
+  const alignments: Alignment[] = Array(cols).fill(alignment);
+  const bodyRowCount = Math.max(0, rows - 1);
+  const bodyRows: string[][] = Array.from({ length: bodyRowCount }, () =>
+    Array(cols).fill('')
+  );
+  const model: TableModel = {
+    headers,
+    alignments,
+    rows: bodyRows,
+    range: new vscode.Range(0, 0, 0, 0),
+    indent: '',
+    eol
+  };
+  return formatTable(model);
+}
+
+export function validateDimension(
+  input: string,
+  label: string,
+  min: number,
+  max: number
+): string | undefined {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return `${label} is required`;
+  if (!/^-?\d+$/.test(trimmed)) return `${label} must be a whole number`;
+  const n = Number(trimmed);
+  if (n < min) return `${label} must be at least ${min}`;
+  if (n > max) return `${label} must be at most ${max}`;
+  return undefined;
+}
+
+export function computePadding(
+  textBefore: string,
+  textAfter: string,
+  eol: string
+): { leading: string; trailing: string } {
+  return {
+    leading: leadingPadding(textBefore, eol),
+    trailing: trailingPadding(textAfter, eol)
+  };
+}
+
+function leadingPadding(textBefore: string, eol: string): string {
+  if (textBefore.length === 0) return '';
+  if (!textBefore.endsWith(eol)) return eol + eol;
+  const beforeNewline = textBefore.slice(0, -eol.length);
+  if (beforeNewline.length === 0 || beforeNewline.endsWith(eol)) return '';
+  return eol;
+}
+
+function trailingPadding(textAfter: string, eol: string): string {
+  if (textAfter.length === 0) return '';
+  if (!textAfter.startsWith(eol)) return eol + eol;
+  const afterNewline = textAfter.slice(eol.length);
+  if (afterNewline.length === 0 || afterNewline.startsWith(eol)) return '';
+  return eol;
+}
+
+export async function insertTableCommand(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return;
+
+  const dims = await pickDimensions();
+  if (!dims) return;
+
+  const config = vscode.workspace.getConfiguration('markdownFoundry');
+  const alignment = config.get<Alignment>('defaultAlignment') ?? 'left';
+  const eol = editor.document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
+
+  const body = buildEmptyTable(dims.rows, dims.cols, alignment, eol);
+
+  const document = editor.document;
+  const selection = editor.selection;
+  const startOffset = document.offsetAt(selection.start);
+  const endOffset = document.offsetAt(selection.end);
+  const fullText = document.getText();
+  const textBefore = fullText.slice(0, startOffset);
+  const textAfter = fullText.slice(endOffset);
+  const { leading, trailing } = computePadding(textBefore, textAfter, eol);
+  const replacement = leading + body + trailing;
+
+  const ok = await editor.edit((edit) => edit.replace(selection, replacement));
+  if (!ok) return;
+
+  const headerOffsetWithinBody = body.indexOf(FIRST_HEADER_LABEL);
+  if (headerOffsetWithinBody < 0) return;
+  const headerStartOffset = startOffset + leading.length + headerOffsetWithinBody;
+  const headerEndOffset = headerStartOffset + FIRST_HEADER_LABEL.length;
+  const start = document.positionAt(headerStartOffset);
+  const end = document.positionAt(headerEndOffset);
+  editor.selection = new vscode.Selection(start, end);
+  editor.revealRange(new vscode.Range(start, end));
+}
+
+async function pickDimensions(): Promise<PresetSize | undefined> {
+  const customLabel = 'Custom...';
+  const items: vscode.QuickPickItem[] = [
+    ...PRESETS.map((p) => ({
+      label: `${p.rows}×${p.cols}`,
+      description: `${p.rows} rows by ${p.cols} columns`
+    })),
+    { label: customLabel, description: 'Enter custom dimensions' }
+  ];
+  const picked = await vscode.window.showQuickPick(items, {
+    placeHolder: 'Table size'
+  });
+  if (!picked) return undefined;
+
+  if (picked.label !== customLabel) {
+    const preset = PRESETS.find((p) => `${p.rows}×${p.cols}` === picked.label);
+    return preset;
+  }
+
+  const rowsInput = await vscode.window.showInputBox({
+    prompt: `Rows (${ROW_MIN}-${ROW_MAX})`,
+    value: '3',
+    validateInput: (v) => validateDimension(v, 'Rows', ROW_MIN, ROW_MAX)
+  });
+  if (rowsInput === undefined) return undefined;
+
+  const colsInput = await vscode.window.showInputBox({
+    prompt: `Columns (${COL_MIN}-${COL_MAX})`,
+    value: '3',
+    validateInput: (v) => validateDimension(v, 'Columns', COL_MIN, COL_MAX)
+  });
+  if (colsInput === undefined) return undefined;
+
+  return { rows: Number(rowsInput.trim()), cols: Number(colsInput.trim()) };
+}

--- a/src/test/suite/insertTable.test.ts
+++ b/src/test/suite/insertTable.test.ts
@@ -1,0 +1,162 @@
+import * as assert from 'assert';
+import {
+  buildEmptyTable,
+  computePadding,
+  validateDimension
+} from '../../insert/insertTable';
+
+suite('insertTable: buildEmptyTable', () => {
+  test('2x2 has header + separator + 1 body row', () => {
+    const out = buildEmptyTable(2, 2, 'left', '\n');
+    const lines = out.split('\n');
+    assert.strictEqual(lines.length, 3);
+    assert.ok(lines[0].includes('Column 1'));
+    assert.ok(lines[0].includes('Column 2'));
+    assert.ok(lines[1].includes(':--'), 'separator uses left alignment marker');
+  });
+
+  test('1xN produces header + separator only (no body rows)', () => {
+    const out = buildEmptyTable(1, 3, 'left', '\n');
+    const lines = out.split('\n');
+    assert.strictEqual(lines.length, 2);
+    assert.ok(lines[0].includes('Column 3'));
+  });
+
+  test('center alignment produces :---: markers', () => {
+    const out = buildEmptyTable(1, 2, 'center', '\n');
+    const separator = out.split('\n')[1];
+    assert.ok(/:-+:/.test(separator), `expected :---: in "${separator}"`);
+  });
+
+  test('right alignment produces ---: markers', () => {
+    const out = buildEmptyTable(1, 2, 'right', '\n');
+    const separator = out.split('\n')[1];
+    assert.ok(/-+:/.test(separator), `expected ---: in "${separator}"`);
+  });
+
+  test('header text increments past Column 9 and Column 10', () => {
+    const out = buildEmptyTable(1, 11, 'left', '\n');
+    const header = out.split('\n')[0];
+    assert.ok(header.includes('Column 9'));
+    assert.ok(header.includes('Column 10'));
+    assert.ok(header.includes('Column 11'));
+  });
+
+  test('CRLF eol is honored', () => {
+    const out = buildEmptyTable(2, 2, 'left', '\r\n');
+    assert.ok(out.includes('\r\n'));
+  });
+
+  test('all body cells start empty', () => {
+    const out = buildEmptyTable(3, 2, 'left', '\n');
+    const lines = out.split('\n');
+    const bodyLines = lines.slice(2);
+    assert.strictEqual(bodyLines.length, 2);
+    for (const line of bodyLines) {
+      const cells = line.split('|').slice(1, -1).map((c) => c.trim());
+      for (const cell of cells) {
+        assert.strictEqual(cell, '', `body cell should be empty, got "${cell}"`);
+      }
+    }
+  });
+});
+
+suite('insertTable: validateDimension', () => {
+  test('accepts an integer in range', () => {
+    assert.strictEqual(validateDimension('5', 'Rows', 1, 50), undefined);
+  });
+
+  test('rejects empty input', () => {
+    const err = validateDimension('', 'Rows', 1, 50);
+    assert.match(err ?? '', /required/);
+  });
+
+  test('rejects non-numeric input', () => {
+    const err = validateDimension('abc', 'Rows', 1, 50);
+    assert.match(err ?? '', /whole number/);
+  });
+
+  test('rejects decimals', () => {
+    const err = validateDimension('2.5', 'Rows', 1, 50);
+    assert.match(err ?? '', /whole number/);
+  });
+
+  test('rejects below min', () => {
+    const err = validateDimension('0', 'Rows', 1, 50);
+    assert.match(err ?? '', /at least 1/);
+  });
+
+  test('rejects above max', () => {
+    const err = validateDimension('51', 'Rows', 1, 50);
+    assert.match(err ?? '', /at most 50/);
+  });
+
+  test('rejects negatives', () => {
+    const err = validateDimension('-3', 'Rows', 1, 50);
+    assert.match(err ?? '', /at least 1/);
+  });
+
+  test('trims whitespace', () => {
+    assert.strictEqual(validateDimension('  5  ', 'Rows', 1, 50), undefined);
+  });
+});
+
+suite('insertTable: computePadding', () => {
+  test('empty document produces no padding', () => {
+    const { leading, trailing } = computePadding('', '', '\n');
+    assert.strictEqual(leading, '');
+    assert.strictEqual(trailing, '');
+  });
+
+  test('non-blank text immediately before requires two newlines of leading', () => {
+    const { leading } = computePadding('hello', '', '\n');
+    assert.strictEqual(leading, '\n\n');
+  });
+
+  test('non-blank text immediately after requires two newlines of trailing', () => {
+    const { trailing } = computePadding('', 'hello', '\n');
+    assert.strictEqual(trailing, '\n\n');
+  });
+
+  test('insertion at start of line after non-blank previous line needs one leading newline', () => {
+    const { leading } = computePadding('hello\n', '', '\n');
+    assert.strictEqual(leading, '\n');
+  });
+
+  test('insertion at start of line after blank previous line needs no leading', () => {
+    const { leading } = computePadding('hello\n\n', '', '\n');
+    assert.strictEqual(leading, '');
+  });
+
+  test('insertion before non-blank line needs two trailing newlines', () => {
+    const { trailing } = computePadding('', 'world', '\n');
+    assert.strictEqual(trailing, '\n\n');
+  });
+
+  test('insertion before line break followed by content needs one trailing newline', () => {
+    const { trailing } = computePadding('', '\nworld', '\n');
+    assert.strictEqual(trailing, '\n');
+  });
+
+  test('insertion before blank line followed by content needs no trailing newlines', () => {
+    const { trailing } = computePadding('', '\n\nworld', '\n');
+    assert.strictEqual(trailing, '');
+  });
+
+  test('insertion at end of document with single trailing newline needs no trailing', () => {
+    const { trailing } = computePadding('', '\n', '\n');
+    assert.strictEqual(trailing, '');
+  });
+
+  test('CRLF: two-newline gaps use \\r\\n boundaries', () => {
+    const { leading, trailing } = computePadding('hello\r\n', '\r\nworld', '\r\n');
+    assert.strictEqual(leading, '\r\n');
+    assert.strictEqual(trailing, '\r\n');
+  });
+
+  test('between two paragraphs: cursor at start of "world" line needs leading and trailing pads', () => {
+    const { leading, trailing } = computePadding('hello\n', 'world', '\n');
+    assert.strictEqual(leading, '\n');
+    assert.strictEqual(trailing, '\n\n');
+  });
+});


### PR DESCRIPTION
## Summary

- New `Insert Table` command (palette-only) that inserts a pre-aligned empty Markdown table at the cursor.
- Quick-pick of preset sizes (2×2, 3×3, 3×2, 4×3, 5×3, 5×4) plus a `Custom...` two-step prompt with validation (rows 1–50, cols 1–20).
- Inserted table is built via the existing `formatTable`, with `markdownFoundry.defaultAlignment` applied to every column. Blank-line padding around the inserted block is computed from surrounding text. After insertion, `Column 1` in the first header cell is selected so the user can type to overwrite.

## Notes

- The local `npm test` harness silently runs zero tests today (mocha is configured to load `dist/test/**/*.test.js`, but the compile pipeline only emits `dist/extension.js`). I ran `npx tsc --noEmit` and `node esbuild.js --production` (both pass) and verified the pure helpers (`validateDimension`, `computePadding`) and the formatter wrapper (`buildEmptyTable`) via stand-alone Node scripts. The new tests in `src/test/suite/insertTable.test.ts` follow the same shape as `formatter.test.ts` so they'll exercise once the test pipeline is fixed — that's a separate concern, not in this PR.

Closes #72