### PR TITLE
fix test pipeline to actually run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,4 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: node esbuild.js --production
+      - run: xvfb-run -a npm test

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   files: 'dist/test/**/*.test.js',
   version: 'stable',
   mocha: {
-    ui: 'bdd',
+    ui: 'tdd',
     timeout: 10000
   }
 });

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
 src/**
+dist/test/**
 .gitignore
 .yarnrc
 esbuild.js

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
-    "compile": "npm run check-types && node esbuild.js",
+    "compile": "npm run check-types && tsc --outDir dist && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",

--- a/src/test/suite/formatter.test.ts
+++ b/src/test/suite/formatter.test.ts
@@ -39,7 +39,7 @@ suite('formatter: formatTable', () => {
     });
     const out = formatTable(model);
     const separator = out.split('\n')[1];
-    assert.ok(separator.includes(':---'), 'left marker present');
+    assert.ok(/:-+(?!:)/.test(separator), 'left marker present');
     assert.ok(/:-+:/.test(separator), 'center marker present');
     assert.ok(/-+:/.test(separator), 'right marker present');
   });

--- a/src/test/suite/toggle.test.ts
+++ b/src/test/suite/toggle.test.ts
@@ -19,7 +19,7 @@ suite('format: wrapInline', () => {
 
   test('does not falsely unwrap a single asterisk when marker is two', () => {
     // `*` is 1 char; `**` would require at least 4 chars to safely contain both ends.
-    assert.strictEqual(wrapInline('*', '**'), '***');
+    assert.strictEqual(wrapInline('*', '**'), '*****');
   });
 
   test('wraps empty string with doubled markers', () => {


### PR DESCRIPTION
## Summary

- `compile` script now emits `dist/test/**/*.js` so mocha can find tests; previously it only bundled `dist/extension.js` via esbuild and the test glob silently matched zero files.
- Mocha UI switched from `bdd` to `tdd` to match the `suite/test` style every test file uses.
- CI gains `xvfb-run -a npm test` — the test gate is now actually enforced.
- Two bit-rotted tests fixed (`wrapInline('*', '**')` expected `***`, correct value is `*****`; left-alignment-marker assertion expected `:---`, but #48 shortened markers to fit column width — now a `:-+(?!:)` regex).
- `.vscodeignore` excludes `dist/test/**` so the test JS files never ship in the .vsix.

89 tests passing locally on this branch (vs. silent 0-test "pass" before).

Closes #76