### PR TITLE
add toggle commands for bullet and numbered lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 ### Added
 
 - `Insert Table` command — pick from preset sizes (2×2 through 5×4) or enter custom dimensions to insert a pre-aligned Markdown table at the cursor. Header cells default to `Column 1`, `Column 2`, … with the first cell selected for immediate editing. Palette-only ([#72](https://github.com/dvlprlife/Markdown-Foundry/pull/72)).
+- `Toggle Bullet List` and `Toggle Numbered List` commands — plain lines become `- ` bullets or `1.`, `2.`, `3.`… numbered items; re-invoke to strip the prefixes. Indentation preserved for nested lists. Palette-only ([#78](https://github.com/dvlprlife/Markdown-Foundry/pull/78)).
 
 ## [0.3.0] - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Markdown Foundry combines fast table editing with one-keystroke Markdown formatt
 
 - **Toggle blockquote** — prefix every non-empty line in the selection with `> `; re-invoke to strip the prefix.
 - **Toggle block code** — wrap the selection with fenced ` ``` ` lines; re-invoke to remove the fence.
+- **Toggle bullet list / numbered list** — prefix every non-empty line in the selection with `- ` or with sequential `1.`/`2.`/`3.`; re-invoke to strip. Leading indentation preserved for nested lists.
 - **Toggle inline code** — wrap the selection with single backticks; re-invoke to unwrap.
 - **Toggle heading levels 1–6** — set the current line to the chosen heading level, or remove the heading if it's already at that level. Plus **Promote / Demote heading** to shift the existing level by one (clamped to H1–H6).
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
       { "command": "markdownFoundry.toggleStrikethrough",     "title": "Toggle Strikethrough",      "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleBlockquote",        "title": "Toggle Blockquote",         "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleBlockCode",         "title": "Toggle Block Code",         "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleBulletList",        "title": "Toggle Bullet List",        "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toggleNumberedList",      "title": "Toggle Numbered List",      "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleInlineCode",        "title": "Toggle Inline Code",        "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleHeading1",          "title": "Toggle Heading 1",          "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleHeading2",          "title": "Toggle Heading 2",          "category": "Markdown Foundry" },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,8 @@ import {
   toggleStrikethroughCommand,
   toggleBlockquoteCommand,
   toggleBlockCodeCommand,
+  toggleBulletListCommand,
+  toggleNumberedListCommand,
   toggleInlineCodeCommand,
   toggleHeading1Command,
   toggleHeading2Command,
@@ -80,6 +82,8 @@ export function activate(context: vscode.ExtensionContext): void {
   register('markdownFoundry.toggleStrikethrough', toggleStrikethroughCommand);
   register('markdownFoundry.toggleBlockquote',    toggleBlockquoteCommand);
   register('markdownFoundry.toggleBlockCode',     toggleBlockCodeCommand);
+  register('markdownFoundry.toggleBulletList',    toggleBulletListCommand);
+  register('markdownFoundry.toggleNumberedList',  toggleNumberedListCommand);
   register('markdownFoundry.toggleInlineCode',    toggleInlineCodeCommand);
   register('markdownFoundry.toggleHeading1',      toggleHeading1Command);
   register('markdownFoundry.toggleHeading2',      toggleHeading2Command);

--- a/src/format/commands.ts
+++ b/src/format/commands.ts
@@ -5,6 +5,8 @@ import {
   wrapLinePrefix,
   wrapHeading,
   adjustHeading,
+  toggleBulletItem,
+  toggleNumberedItem,
   toggleTaskItem
 } from './toggle';
 
@@ -76,6 +78,14 @@ export async function toggleBlockquoteCommand(): Promise<void> {
 
 export async function toggleBlockCodeCommand(): Promise<void> {
   await applyLineRange((text) => wrapFenced(text));
+}
+
+export async function toggleBulletListCommand(): Promise<void> {
+  await applyLineRange(toggleBulletItem);
+}
+
+export async function toggleNumberedListCommand(): Promise<void> {
+  await applyLineRange(toggleNumberedItem);
 }
 
 /**

--- a/src/format/toggle.ts
+++ b/src/format/toggle.ts
@@ -83,6 +83,53 @@ export function adjustHeading(line: string, delta: number): string {
  * Preserves leading indentation. A bullet line without a checkbox (`- x`) is
  * promoted to an unchecked task (`- [ ] x`).
  */
+const BULLET_RE = /^(\s*)([-*+])\s+/;
+
+/**
+ * Toggle a bullet list prefix on every non-empty line. If every non-empty
+ * line is already bulleted (with `-`, `*`, or `+`), strips the prefix;
+ * otherwise prepends `- ` to every non-empty line. Leading indentation is
+ * preserved so nested lists round-trip cleanly.
+ */
+export function toggleBulletItem(text: string): string {
+  const lines = text.split(/\r?\n/);
+  const allBulleted = lines.every((l) => l === '' || BULLET_RE.test(l));
+
+  if (allBulleted) {
+    return lines.map((l) => l.replace(BULLET_RE, '$1')).join('\n');
+  }
+  return lines
+    .map((l) => (l === '' ? l : l.replace(/^(\s*)/, '$1- ')))
+    .join('\n');
+}
+
+const NUMBERED_RE = /^(\s*)\d+\.\s+/;
+
+/**
+ * Toggle a numbered list prefix on every non-empty line. If every non-empty
+ * line is already numbered (`N. `), strips the prefix; otherwise prepends
+ * sequential `1. `, `2. `, … starting at 1 (incrementing globally across
+ * the selection, including indented lines).
+ */
+export function toggleNumberedItem(text: string): string {
+  const lines = text.split(/\r?\n/);
+  const allNumbered = lines.every((l) => l === '' || NUMBERED_RE.test(l));
+
+  if (allNumbered) {
+    return lines.map((l) => l.replace(NUMBERED_RE, '$1')).join('\n');
+  }
+  let n = 1;
+  return lines
+    .map((l) => {
+      if (l === '') return l;
+      const m = l.match(/^(\s*)(.*)$/);
+      const indent = m ? m[1] : '';
+      const body = m ? m[2] : l;
+      return `${indent}${n++}. ${body}`;
+    })
+    .join('\n');
+}
+
 export function toggleTaskItem(line: string): string {
   const indentMatch = line.match(/^(\s*)(.*)$/);
   const indent = indentMatch ? indentMatch[1] : '';

--- a/src/test/suite/toggle.test.ts
+++ b/src/test/suite/toggle.test.ts
@@ -5,6 +5,8 @@ import {
   wrapLinePrefix,
   wrapHeading,
   adjustHeading,
+  toggleBulletItem,
+  toggleNumberedItem,
   toggleTaskItem
 } from '../../format/toggle';
 
@@ -186,5 +188,98 @@ suite('format: toggleTaskItem', () => {
   test('preserves leading indentation when toggling check state', () => {
     assert.strictEqual(toggleTaskItem('  - [ ] do laundry'), '  - [x] do laundry');
     assert.strictEqual(toggleTaskItem('  - [x] do laundry'), '  - [ ] do laundry');
+  });
+});
+
+suite('format: toggleBulletItem', () => {
+  test('plain line becomes a bullet', () => {
+    assert.strictEqual(toggleBulletItem('hello'), '- hello');
+  });
+
+  test('bullet line is stripped', () => {
+    assert.strictEqual(toggleBulletItem('- hello'), 'hello');
+  });
+
+  test('asterisk bullet is stripped (toggle-off accepts any bullet char)', () => {
+    assert.strictEqual(toggleBulletItem('* hello'), 'hello');
+  });
+
+  test('plus bullet is stripped', () => {
+    assert.strictEqual(toggleBulletItem('+ hello'), 'hello');
+  });
+
+  test('multi-line plain → all prefixed with `- `', () => {
+    assert.strictEqual(
+      toggleBulletItem('one\ntwo\nthree'),
+      '- one\n- two\n- three'
+    );
+  });
+
+  test('multi-line all-bulleted → all stripped', () => {
+    assert.strictEqual(
+      toggleBulletItem('- one\n- two\n- three'),
+      'one\ntwo\nthree'
+    );
+  });
+
+  test('mixed (some bulleted, some plain) → wrap path: every line gets `- `', () => {
+    assert.strictEqual(
+      toggleBulletItem('- foo\nbar'),
+      '- - foo\n- bar'
+    );
+  });
+
+  test('preserves leading indentation when stripping', () => {
+    assert.strictEqual(toggleBulletItem('  - hello'), '  hello');
+  });
+
+  test('empty lines pass through unchanged on toggle-on', () => {
+    assert.strictEqual(toggleBulletItem('foo\n\nbar'), '- foo\n\n- bar');
+  });
+
+  test('empty lines pass through unchanged on toggle-off', () => {
+    assert.strictEqual(toggleBulletItem('- foo\n\n- bar'), 'foo\n\nbar');
+  });
+});
+
+suite('format: toggleNumberedItem', () => {
+  test('plain line becomes `1. line`', () => {
+    assert.strictEqual(toggleNumberedItem('hello'), '1. hello');
+  });
+
+  test('three plain lines become `1.`/`2.`/`3.`', () => {
+    assert.strictEqual(
+      toggleNumberedItem('one\ntwo\nthree'),
+      '1. one\n2. two\n3. three'
+    );
+  });
+
+  test('numbered line is stripped', () => {
+    assert.strictEqual(toggleNumberedItem('1. hello'), 'hello');
+  });
+
+  test('three numbered lines → all stripped', () => {
+    assert.strictEqual(
+      toggleNumberedItem('1. one\n2. two\n3. three'),
+      'one\ntwo\nthree'
+    );
+  });
+
+  test('preserves leading indentation when stripping', () => {
+    assert.strictEqual(toggleNumberedItem('  1. hello'), '  hello');
+  });
+
+  test('indented lines preserve indent and increment globally', () => {
+    assert.strictEqual(
+      toggleNumberedItem('one\n  two\nthree'),
+      '1. one\n  2. two\n3. three'
+    );
+  });
+
+  test('empty lines pass through and do not consume a number', () => {
+    assert.strictEqual(
+      toggleNumberedItem('one\n\ntwo'),
+      '1. one\n\n2. two'
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Two new palette-only commands: `Toggle Bullet List` and `Toggle Numbered List`.
- Both line-oriented (use `applyLineRange`, same harness as Toggle Blockquote / Toggle Block Code).
- Pure helpers `toggleBulletItem` and `toggleNumberedItem` added to `src/format/toggle.ts`; covered by 17 new unit tests.
- Bullet toggle accepts any of `-`/`*`/`+` for toggle-off; emits `- ` for toggle-on. Mixed input (some bulleted, some plain) takes the wrap path producing valid nested-list markup.
- Numbered toggle increments globally across the selection (indented lines preserve indent, but the counter still advances). Empty lines pass through and don't consume a number.

Closes #62