### PR TITLE
add table-of-contents generation command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 - `Insert Table` command — pick from preset sizes (2×2 through 5×4) or enter custom dimensions to insert a pre-aligned Markdown table at the cursor. Header cells default to `Column 1`, `Column 2`, … with the first cell selected for immediate editing. Palette-only ([#72](https://github.com/dvlprlife/Markdown-Foundry/pull/72)).
 - `Toggle Bullet List` and `Toggle Numbered List` commands — plain lines become `- ` bullets or `1.`, `2.`, `3.`… numbered items; re-invoke to strip the prefixes. Indentation preserved for nested lists. Palette-only ([#78](https://github.com/dvlprlife/Markdown-Foundry/pull/78)).
+- `Insert/Update Table of Contents` command — generates a nested Markdown TOC from the document's headings and wraps it in `<!-- markdownfoundry-toc -->` / `<!-- /markdownfoundry-toc -->` markers so subsequent invocations update in place rather than duplicate. Headings inside fenced code blocks and HTML comments are skipped. GitHub-compatible slug generation (with `-1`, `-2` suffixes for duplicates). Configurable depth filter and indent via four new `markdownFoundry.toc.*` settings ([#79](https://github.com/dvlprlife/Markdown-Foundry/pull/79)).
 
 ## [0.3.0] - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Markdown Foundry combines fast table editing with one-keystroke Markdown formatt
   ![Toggle a task list item between plain, unchecked, and checked](images/demo/tasklist.gif)
 - **Insert horizontal rule** — drop a `---` line below the cursor's current line.
 
+### Structure
+
+- **Insert/Update Table of Contents** — Generate a nested Markdown TOC from the document's headings and wrap it in `<!-- markdownfoundry-toc -->` markers so subsequent invocations update in place rather than duplicate. Headings inside fenced code blocks and HTML comments are skipped; duplicate headings get `-1`/`-2`/… slug suffixes. Depth filter and indent are configurable via the `markdownFoundry.toc.*` settings.
+
 ## Keybindings
 
 | Shortcut | Command |
@@ -73,6 +77,10 @@ All other commands are available through the Command Palette (search for "Markdo
 | `markdownFoundry.defaultAlignment` | `"left"` | Alignment for new columns. |
 | `markdownFoundry.imageFolder` | `"images"` | Folder (relative to the file) where pasted images are saved. |
 | `markdownFoundry.imageNameFormat` | `"image-${timestamp}"` | Template for pasted image filenames. Tokens: `${timestamp}`, `${date}`, `${filename}`. |
+| `markdownFoundry.toc.minDepth` | `2` | Lowest heading level included in the table of contents. |
+| `markdownFoundry.toc.maxDepth` | `6` | Highest heading level included in the table of contents. |
+| `markdownFoundry.toc.indent` | `2` | Spaces of indentation per heading depth level. |
+| `markdownFoundry.toc.includeMarkers` | `true` | Wrap the TOC in HTML comment markers so it can be updated in place. |
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
       { "command": "markdownFoundry.promoteHeading",          "title": "Promote Heading",           "category": "Markdown Foundry" },
       { "command": "markdownFoundry.demoteHeading",           "title": "Demote Heading",            "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleTaskList",          "title": "Toggle Task List Item",     "category": "Markdown Foundry" },
-      { "command": "markdownFoundry.insertHorizontalRule",    "title": "Insert Horizontal Rule",    "category": "Markdown Foundry" }
+      { "command": "markdownFoundry.insertHorizontalRule",    "title": "Insert Horizontal Rule",    "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.toc",                     "title": "Insert/Update Table of Contents", "category": "Markdown Foundry" }
     ],
     "keybindings": [
       {
@@ -139,6 +140,31 @@
           "type": "string",
           "default": "image-${timestamp}",
           "description": "Filename template for pasted images. Supported tokens: ${timestamp}, ${filename}, ${date}."
+        },
+        "markdownFoundry.toc.minDepth": {
+          "type": "number",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 6,
+          "description": "Lowest heading level included in the generated table of contents (1 = include H1)."
+        },
+        "markdownFoundry.toc.maxDepth": {
+          "type": "number",
+          "default": 6,
+          "minimum": 1,
+          "maximum": 6,
+          "description": "Highest heading level included in the generated table of contents."
+        },
+        "markdownFoundry.toc.indent": {
+          "type": "number",
+          "default": 2,
+          "minimum": 0,
+          "description": "Spaces of indentation per heading depth level in the generated table of contents."
+        },
+        "markdownFoundry.toc.includeMarkers": {
+          "type": "boolean",
+          "default": true,
+          "description": "Wrap the generated table of contents in <!-- markdownfoundry-toc --> markers so it can be updated in place. If false, the command always inserts at the cursor."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import {
 import { sortByColumnCommand } from './table/commands/sort';
 import { convertSelectionToTableCommand } from './table/commands/convert';
 import { insertTableCommand } from './insert/insertTable';
+import { upsertTOCCommand } from './structure/commands/toc';
 import { pasteLinkCommand } from './insert/link';
 import { pasteImageCommand } from './insert/image';
 import {
@@ -95,6 +96,9 @@ export function activate(context: vscode.ExtensionContext): void {
   register('markdownFoundry.demoteHeading',       demoteHeadingCommand);
   register('markdownFoundry.toggleTaskList',      toggleTaskListCommand);
   register('markdownFoundry.insertHorizontalRule', insertHorizontalRuleCommand);
+
+  // Structure
+  register('markdownFoundry.toc', upsertTOCCommand);
 
   // Context key for Tab/Shift-Tab/Enter bindings
   registerInTableContext(context);

--- a/src/structure/commands/toc.ts
+++ b/src/structure/commands/toc.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+import {
+  TOCOptions,
+  extractHeadings,
+  generateTOC,
+  locateExistingTOC
+} from '../toc';
+
+export async function upsertTOCCommand(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return;
+
+  const document = editor.document;
+  const text = document.getText();
+  const options = readOptions();
+  const headings = extractHeadings(text);
+  const toc = generateTOC(headings, options);
+
+  if (!options.includeMarkers) {
+    const cursor = editor.selection.active;
+    await editor.edit((edit) => edit.insert(cursor, toc));
+    return;
+  }
+
+  const existing = locateExistingTOC(text);
+  if (existing) {
+    const start = document.positionAt(existing.startOffset);
+    const end = document.positionAt(existing.endOffset);
+    await editor.edit((edit) => edit.replace(new vscode.Range(start, end), toc));
+    return;
+  }
+
+  const cursor = editor.selection.active;
+  await editor.edit((edit) => edit.insert(cursor, toc));
+}
+
+function readOptions(): TOCOptions {
+  const config = vscode.workspace.getConfiguration('markdownFoundry.toc');
+  return {
+    minDepth: config.get<number>('minDepth') ?? 2,
+    maxDepth: config.get<number>('maxDepth') ?? 6,
+    indent: config.get<number>('indent') ?? 2,
+    includeMarkers: config.get<boolean>('includeMarkers') ?? true
+  };
+}

--- a/src/structure/toc.ts
+++ b/src/structure/toc.ts
@@ -1,0 +1,138 @@
+export interface Heading {
+  level: number;
+  text: string;
+  slug: string;
+}
+
+export interface TOCOptions {
+  minDepth: number;
+  maxDepth: number;
+  indent: number;
+  includeMarkers: boolean;
+}
+
+export const TOC_OPEN_MARKER = '<!-- markdownfoundry-toc -->';
+export const TOC_CLOSE_MARKER = '<!-- /markdownfoundry-toc -->';
+
+const HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
+const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})/;
+
+export function extractHeadings(text: string): Heading[] {
+  const lines = text.split(/\r?\n/);
+  const headings: Heading[] = [];
+  let fenceMarker: string | undefined;
+  let inHtmlComment = false;
+
+  for (const raw of lines) {
+    if (fenceMarker !== undefined) {
+      const closeMatch = raw.match(FENCE_RE);
+      if (closeMatch && closeMatch[1].startsWith(fenceMarker)) {
+        fenceMarker = undefined;
+      }
+      continue;
+    }
+
+    let line = raw;
+    if (inHtmlComment) {
+      const closeIdx = line.indexOf('-->');
+      if (closeIdx < 0) continue;
+      line = line.slice(closeIdx + 3);
+      inHtmlComment = false;
+    }
+
+    const stripped = stripInlineHtmlComments(line);
+    const trailingOpen = stripped.lastIndexOf('<!--');
+    let lineToScan = stripped;
+    if (trailingOpen >= 0) {
+      inHtmlComment = true;
+      lineToScan = stripped.slice(0, trailingOpen);
+    }
+
+    const fenceOpen = lineToScan.match(FENCE_RE);
+    if (fenceOpen) {
+      fenceMarker = fenceOpen[1];
+      continue;
+    }
+
+    const m = lineToScan.match(HEADING_RE);
+    if (!m) continue;
+    const level = m[1].length;
+    const text = m[2];
+    const slug = slugify(text);
+    headings.push({ level, text, slug });
+  }
+
+  return dedupeSlugs(headings);
+}
+
+function stripInlineHtmlComments(line: string): string {
+  let out = '';
+  let i = 0;
+  while (i < line.length) {
+    const open = line.indexOf('<!--', i);
+    if (open < 0) {
+      out += line.slice(i);
+      break;
+    }
+    out += line.slice(i, open);
+    const close = line.indexOf('-->', open + 4);
+    if (close < 0) {
+      out += line.slice(open);
+      break;
+    }
+    i = close + 3;
+  }
+  return out;
+}
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9\-_]/g, '');
+}
+
+export function dedupeSlugs(headings: Heading[]): Heading[] {
+  const seen = new Map<string, number>();
+  return headings.map((h) => {
+    if (h.slug === '') return h;
+    const count = seen.get(h.slug) ?? 0;
+    seen.set(h.slug, count + 1);
+    if (count === 0) return h;
+    return { ...h, slug: `${h.slug}-${count}` };
+  });
+}
+
+export function generateTOC(headings: Heading[], options: TOCOptions): string {
+  const filtered = headings.filter(
+    (h) => h.level >= options.minDepth && h.level <= options.maxDepth && h.slug !== ''
+  );
+  if (filtered.length === 0) {
+    return options.includeMarkers
+      ? `${TOC_OPEN_MARKER}\n${TOC_CLOSE_MARKER}`
+      : '';
+  }
+  const indent = ' '.repeat(options.indent);
+  const lines = filtered.map((h) => {
+    const depth = h.level - options.minDepth;
+    return `${indent.repeat(depth)}- [${h.text}](#${h.slug})`;
+  });
+  const body = lines.join('\n');
+  if (!options.includeMarkers) return body;
+  return `${TOC_OPEN_MARKER}\n${body}\n${TOC_CLOSE_MARKER}`;
+}
+
+export interface TOCRange {
+  startOffset: number;
+  endOffset: number;
+}
+
+export function locateExistingTOC(text: string): TOCRange | undefined {
+  const startOffset = text.indexOf(TOC_OPEN_MARKER);
+  if (startOffset < 0) return undefined;
+  const endSearchFrom = startOffset + TOC_OPEN_MARKER.length;
+  const endOffset = text.indexOf(TOC_CLOSE_MARKER, endSearchFrom);
+  if (endOffset < 0) return undefined;
+  return { startOffset, endOffset: endOffset + TOC_CLOSE_MARKER.length };
+}

--- a/src/test/suite/toc.test.ts
+++ b/src/test/suite/toc.test.ts
@@ -1,0 +1,246 @@
+import * as assert from 'assert';
+import {
+  TOC_CLOSE_MARKER,
+  TOC_OPEN_MARKER,
+  TOCOptions,
+  dedupeSlugs,
+  extractHeadings,
+  generateTOC,
+  locateExistingTOC,
+  slugify
+} from '../../structure/toc';
+
+const DEFAULT_OPTIONS: TOCOptions = {
+  minDepth: 1,
+  maxDepth: 6,
+  indent: 2,
+  includeMarkers: true
+};
+
+suite('toc: slugify', () => {
+  test('lowercases and hyphenates whitespace', () => {
+    assert.strictEqual(slugify('Hello World'), 'hello-world');
+  });
+
+  test('drops punctuation', () => {
+    assert.strictEqual(slugify("Don't Repeat Yourself!"), 'dont-repeat-yourself');
+  });
+
+  test('preserves underscores and digits', () => {
+    assert.strictEqual(slugify('foo_bar 123'), 'foo_bar-123');
+  });
+
+  test('collapses multiple spaces to single hyphen', () => {
+    assert.strictEqual(slugify('a    b'), 'a-b');
+  });
+
+  test('returns empty string for non-alphanumeric input', () => {
+    assert.strictEqual(slugify('???'), '');
+  });
+
+  test('trims surrounding whitespace', () => {
+    assert.strictEqual(slugify('  hello  '), 'hello');
+  });
+});
+
+suite('toc: dedupeSlugs', () => {
+  test('first occurrence keeps base slug, subsequent get -N', () => {
+    const result = dedupeSlugs([
+      { level: 2, text: 'Setup', slug: 'setup' },
+      { level: 2, text: 'Setup', slug: 'setup' },
+      { level: 2, text: 'Setup', slug: 'setup' }
+    ]);
+    assert.deepStrictEqual(
+      result.map((h) => h.slug),
+      ['setup', 'setup-1', 'setup-2']
+    );
+  });
+
+  test('preserves empty slugs without numbering', () => {
+    const result = dedupeSlugs([
+      { level: 2, text: '', slug: '' },
+      { level: 2, text: '???', slug: '' }
+    ]);
+    assert.deepStrictEqual(
+      result.map((h) => h.slug),
+      ['', '']
+    );
+  });
+
+  test('different slugs are independent counters', () => {
+    const result = dedupeSlugs([
+      { level: 2, text: 'A', slug: 'a' },
+      { level: 2, text: 'B', slug: 'b' },
+      { level: 2, text: 'A', slug: 'a' }
+    ]);
+    assert.deepStrictEqual(
+      result.map((h) => h.slug),
+      ['a', 'b', 'a-1']
+    );
+  });
+});
+
+suite('toc: extractHeadings', () => {
+  test('extracts single heading at each depth', () => {
+    const result = extractHeadings('# A\n## B\n### C');
+    assert.deepStrictEqual(result, [
+      { level: 1, text: 'A', slug: 'a' },
+      { level: 2, text: 'B', slug: 'b' },
+      { level: 3, text: 'C', slug: 'c' }
+    ]);
+  });
+
+  test('skips headings inside backtick fenced code blocks', () => {
+    const text = '# Real\n```\n# Fake\n```\n## Another Real';
+    const result = extractHeadings(text);
+    assert.deepStrictEqual(
+      result.map((h) => h.text),
+      ['Real', 'Another Real']
+    );
+  });
+
+  test('skips headings inside tilde fenced code blocks', () => {
+    const text = '# Real\n~~~\n# Fake\n~~~\n## Another Real';
+    const result = extractHeadings(text);
+    assert.deepStrictEqual(
+      result.map((h) => h.text),
+      ['Real', 'Another Real']
+    );
+  });
+
+  test('skips headings inside multi-line HTML comments', () => {
+    const text = '# Real\n<!--\n# Fake\n-->\n## Another Real';
+    const result = extractHeadings(text);
+    assert.deepStrictEqual(
+      result.map((h) => h.text),
+      ['Real', 'Another Real']
+    );
+  });
+
+  test('handles inline HTML comments on the same line', () => {
+    const text = '# Heading <!-- side note --> Trailing\n## Body';
+    const result = extractHeadings(text);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].level, 1);
+    assert.strictEqual(result[1].text, 'Body');
+  });
+
+  test('deduplicates repeated heading text via slug suffix', () => {
+    const text = '## Setup\n## Setup\n## Setup';
+    const result = extractHeadings(text);
+    assert.deepStrictEqual(
+      result.map((h) => h.slug),
+      ['setup', 'setup-1', 'setup-2']
+    );
+  });
+
+  test('handles CRLF line endings', () => {
+    const result = extractHeadings('# A\r\n## B');
+    assert.deepStrictEqual(
+      result.map((h) => h.level),
+      [1, 2]
+    );
+  });
+
+  test('ignores lines that look like headings but lack the space', () => {
+    const result = extractHeadings('#NotAHeading\n# Real');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].text, 'Real');
+  });
+});
+
+suite('toc: generateTOC', () => {
+  test('renders nested list with default markers and indent', () => {
+    const headings = [
+      { level: 1, text: 'A', slug: 'a' },
+      { level: 2, text: 'B', slug: 'b' },
+      { level: 3, text: 'C', slug: 'c' }
+    ];
+    const out = generateTOC(headings, DEFAULT_OPTIONS);
+    const expected = [
+      TOC_OPEN_MARKER,
+      '- [A](#a)',
+      '  - [B](#b)',
+      '    - [C](#c)',
+      TOC_CLOSE_MARKER
+    ].join('\n');
+    assert.strictEqual(out, expected);
+  });
+
+  test('respects minDepth filter and indents from minDepth', () => {
+    const headings = [
+      { level: 1, text: 'Skip', slug: 'skip' },
+      { level: 2, text: 'A', slug: 'a' },
+      { level: 3, text: 'B', slug: 'b' }
+    ];
+    const out = generateTOC(headings, { ...DEFAULT_OPTIONS, minDepth: 2 });
+    assert.ok(!out.includes('- [Skip]'), 'H1 filtered');
+    assert.ok(out.includes('- [A](#a)'));
+    assert.ok(out.includes('  - [B](#b)'));
+  });
+
+  test('respects maxDepth filter', () => {
+    const headings = [
+      { level: 1, text: 'A', slug: 'a' },
+      { level: 2, text: 'B', slug: 'b' },
+      { level: 4, text: 'Skip', slug: 'skip' }
+    ];
+    const out = generateTOC(headings, { ...DEFAULT_OPTIONS, maxDepth: 2 });
+    assert.ok(!out.includes('Skip'));
+    assert.ok(out.includes('A'));
+    assert.ok(out.includes('B'));
+  });
+
+  test('skips headings with empty slugs', () => {
+    const headings = [
+      { level: 1, text: 'A', slug: 'a' },
+      { level: 2, text: '???', slug: '' }
+    ];
+    const out = generateTOC(headings, DEFAULT_OPTIONS);
+    assert.ok(out.includes('- [A](#a)'));
+    assert.ok(!out.includes('???'));
+  });
+
+  test('without markers produces only the list', () => {
+    const headings = [{ level: 1, text: 'A', slug: 'a' }];
+    const out = generateTOC(headings, { ...DEFAULT_OPTIONS, includeMarkers: false });
+    assert.strictEqual(out, '- [A](#a)');
+  });
+
+  test('empty filtered set with markers returns just the marker pair', () => {
+    const out = generateTOC([], DEFAULT_OPTIONS);
+    assert.strictEqual(out, `${TOC_OPEN_MARKER}\n${TOC_CLOSE_MARKER}`);
+  });
+
+  test('empty filtered set without markers returns empty string', () => {
+    const out = generateTOC([], { ...DEFAULT_OPTIONS, includeMarkers: false });
+    assert.strictEqual(out, '');
+  });
+
+  test('custom indent width', () => {
+    const headings = [
+      { level: 1, text: 'A', slug: 'a' },
+      { level: 2, text: 'B', slug: 'b' }
+    ];
+    const out = generateTOC(headings, { ...DEFAULT_OPTIONS, indent: 4 });
+    assert.ok(out.includes('    - [B](#b)'));
+  });
+});
+
+suite('toc: locateExistingTOC', () => {
+  test('returns range for an existing TOC block', () => {
+    const text = `intro\n${TOC_OPEN_MARKER}\n- [A](#a)\n${TOC_CLOSE_MARKER}\noutro`;
+    const range = locateExistingTOC(text);
+    assert.ok(range !== undefined);
+    assert.strictEqual(text.slice(range.startOffset, range.endOffset).startsWith(TOC_OPEN_MARKER), true);
+    assert.strictEqual(text.slice(range.startOffset, range.endOffset).endsWith(TOC_CLOSE_MARKER), true);
+  });
+
+  test('returns undefined when no markers present', () => {
+    assert.strictEqual(locateExistingTOC('just text'), undefined);
+  });
+
+  test('returns undefined when only the open marker is present', () => {
+    assert.strictEqual(locateExistingTOC(`text ${TOC_OPEN_MARKER} more`), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- New `markdownFoundry.toc` command: **Insert/Update Table of Contents**.
- Scans the whole document for headings (skipping fenced code blocks — backtick and tilde — and HTML comments), produces a nested Markdown list, wraps it in `<!-- markdownfoundry-toc -->` / `<!-- /markdownfoundry-toc -->` markers so the same invocation updates in place rather than duplicating.
- GitHub-compatible slug generation with `-1`/`-2`/… deduping for repeated heading text.
- Four new config keys: `markdownFoundry.toc.{minDepth,maxDepth,indent,includeMarkers}`.
- New top-level `src/structure/` directory for non-table structural commands. Pure helpers in `src/structure/toc.ts`; impure command in `src/structure/commands/toc.ts`. 28 new unit tests covering slugify, dedupe, fenced/HTML-comment exclusion, depth filtering, indent, and marker location.

## Architectural note

This command intentionally **scans the whole document**, which seems to violate CLAUDE.md's "locate, don't parse" rule. That rule was written for *table* commands (each operating on a single table). TOC generation by definition needs every heading. Calling this out so the reviewer doesn't flag it as a violation.

Closes #14