### PR TITLE
bump to v0.4.0 and roll over changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-02
+
 ### Added
 
-- `Insert Table` command — pick from preset sizes (2×2 through 5×4) or enter custom dimensions to insert a pre-aligned Markdown table at the cursor. Header cells default to `Column 1`, `Column 2`, … with the first cell selected for immediate editing. Palette-only ([#72](https://github.com/dvlprlife/Markdown-Foundry/pull/72)).
+- `Insert Table` command — pick from preset sizes (2×2 through 5×4) or enter custom dimensions to insert a pre-aligned Markdown table at the cursor. Header cells default to `Column 1`, `Column 2`, … with the first cell selected for immediate editing. Palette-only ([#75](https://github.com/dvlprlife/Markdown-Foundry/pull/75)).
 - `Toggle Bullet List` and `Toggle Numbered List` commands — plain lines become `- ` bullets or `1.`, `2.`, `3.`… numbered items; re-invoke to strip the prefixes. Indentation preserved for nested lists. Palette-only ([#78](https://github.com/dvlprlife/Markdown-Foundry/pull/78)).
 - `Insert/Update Table of Contents` command — generates a nested Markdown TOC from the document's headings and wraps it in `<!-- markdownfoundry-toc -->` / `<!-- /markdownfoundry-toc -->` markers so subsequent invocations update in place rather than duplicate. Headings inside fenced code blocks and HTML comments are skipped. GitHub-compatible slug generation (with `-1`, `-2` suffixes for duplicates). Configurable depth filter and indent via four new `markdownFoundry.toc.*` settings ([#79](https://github.com/dvlprlife/Markdown-Foundry/pull/79)).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdfoundry",
   "displayName": "Markdown Foundry",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publisher": "dvlprlife",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

- \`package.json\` version: \`0.3.0\` → \`0.4.0\`
- \`CHANGELOG.md\`: previous \`[Unreleased]\` section renamed to \`[0.4.0] - 2026-05-02\`; fresh empty \`[Unreleased]\` added above
- Fixed an incorrect PR link in the CHANGELOG (Insert Table → PR #75, was #72 which is the issue number)

Closes #80