### PR TITLE
extend pasteLink to accept file paths and file:// URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Changed
+
+- `Paste Link` now also accepts absolute file paths and `file://` URIs from the clipboard, inserting them as relative-path links. Image extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`, `.ico`) are inserted as `![alt](path)`; everything else as `[text](path)`. Non-existent paths are rejected so typos don't sneak in. ([#84](https://github.com/dvlprlife/Markdown-Foundry/pull/84))
+
 ## [0.4.0] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Markdown Foundry combines fast table editing with one-keystroke Markdown formatt
 
 ### Insertion commands
 
-- **Paste Link** — If the clipboard contains a URL, wrap the selection (or prompt for text) and insert `[text](url)`.
+- **Paste Link** — Insert a Markdown link from the clipboard. Accepts URLs (`https://...`), absolute file paths, and `file://` URIs. URLs and non-image files become `[text](...)`; image files become `![alt](...)`. With a selection, uses it as the link text; otherwise prompts (default = basename for files, URL for URLs).
 - **Paste Image** — Save the clipboard image to a configurable folder and insert a Markdown image reference. On Linux, requires `xclip` (X11) or `wl-clipboard` (Wayland) to be installed.
 
 ### Formatting

--- a/src/insert/imageExtensions.ts
+++ b/src/insert/imageExtensions.ts
@@ -1,0 +1,16 @@
+import * as path from 'path';
+
+export const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.svg',
+  '.bmp',
+  '.ico'
+]);
+
+export function isImageExtension(filename: string): boolean {
+  return IMAGE_EXTENSIONS.has(path.extname(filename).toLowerCase());
+}

--- a/src/insert/link.ts
+++ b/src/insert/link.ts
@@ -1,40 +1,128 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { URL as NodeURL } from 'url';
+import { isImageExtension } from './imageExtensions';
+
+export type ClipboardKind =
+  | { kind: 'url'; value: string }
+  | { kind: 'path'; absPath: string; isImage: boolean }
+  | { kind: 'none' };
 
 const URL_RE = /^https?:\/\/\S+$/i;
 
-/**
- * Paste the clipboard contents as a Markdown link.
- *
- * Behavior:
- *   - If clipboard is a URL:
- *       - If there is a selection, wrap it: [selected](url)
- *       - Else prompt for link text (or use the URL as text if prompt is empty)
- *   - If clipboard is not a URL, show info message.
- */
+interface ClassifyOptions {
+  platform?: NodeJS.Platform;
+  existsSync?: (p: string) => boolean;
+}
+
+export function classifyClipboard(raw: string, options: ClassifyOptions = {}): ClipboardKind {
+  const platform = options.platform ?? process.platform;
+  const exists = options.existsSync ?? fs.existsSync;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return { kind: 'none' };
+
+  if (URL_RE.test(trimmed)) {
+    return { kind: 'url', value: trimmed };
+  }
+
+  if (/^file:\/\//i.test(trimmed)) {
+    try {
+      const url = new NodeURL(trimmed);
+      if (url.pathname === '' || url.pathname === '/') return { kind: 'none' };
+      let p = decodeURIComponent(url.pathname);
+      if (platform === 'win32' && /^\/[A-Za-z]:/.test(p)) {
+        p = p.slice(1);
+      }
+      if (platform === 'win32') p = p.replace(/\//g, '\\');
+      if (isAbsoluteAcross(p, platform) && exists(p)) {
+        return { kind: 'path', absPath: p, isImage: isImageExtension(p) };
+      }
+    } catch {
+      // fall through to 'none'
+    }
+    return { kind: 'none' };
+  }
+
+  if (isAbsoluteAcross(trimmed, platform) && exists(trimmed)) {
+    return { kind: 'path', absPath: trimmed, isImage: isImageExtension(trimmed) };
+  }
+
+  return { kind: 'none' };
+}
+
+function isAbsoluteAcross(p: string, platform: NodeJS.Platform): boolean {
+  return platform === 'win32' ? path.win32.isAbsolute(p) : path.posix.isAbsolute(p);
+}
+
 export async function pasteLinkCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
   if (!editor) return;
 
-  const clipboard = (await vscode.env.clipboard.readText()).trim();
-  if (!URL_RE.test(clipboard)) {
-    vscode.window.showInformationMessage('Markdown Foundry: clipboard does not contain a URL.');
+  const document = editor.document;
+  const raw = await vscode.env.clipboard.readText();
+  const result = classifyClipboard(raw);
+
+  if (result.kind === 'none') {
+    vscode.window.showInformationMessage(
+      'Markdown Foundry: clipboard does not contain a URL or file path.'
+    );
     return;
   }
 
   const selection = editor.selection;
-  let linkText: string;
-  if (!selection.isEmpty) {
-    linkText = editor.document.getText(selection);
-  } else {
-    const input = await vscode.window.showInputBox({
-      prompt: 'Link text (leave empty to use the URL)',
-      placeHolder: clipboard
-    });
-    if (input === undefined) return; // user cancelled
-    linkText = input.length > 0 ? input : clipboard;
+  const selectedText = selection.isEmpty ? '' : document.getText(selection);
+
+  if (result.kind === 'url') {
+    const url = result.value;
+    const text = await resolveLinkText(
+      selectedText,
+      url,
+      'Link text (leave empty to use the URL)'
+    );
+    if (text === undefined) return;
+    await applyEdit(editor, selection, `[${text}](${url})`);
+    return;
   }
 
-  const markdown = `[${linkText}](${clipboard})`;
+  if (document.uri.scheme !== 'file') {
+    vscode.window.showInformationMessage(
+      'Markdown Foundry: file-path link requires a saved file.'
+    );
+    return;
+  }
+
+  const docDir = path.dirname(document.uri.fsPath);
+  const rel = path.relative(docDir, result.absPath).split(path.sep).join('/');
+  const fallback = path.basename(result.absPath, path.extname(result.absPath));
+
+  const text = await resolveLinkText(
+    selectedText,
+    fallback,
+    `Link text (leave empty to use ${fallback})`
+  );
+  if (text === undefined) return;
+
+  const markdown = result.isImage ? `![${text}](${rel})` : `[${text}](${rel})`;
+  await applyEdit(editor, selection, markdown);
+}
+
+async function resolveLinkText(
+  selectedText: string,
+  fallback: string,
+  prompt: string
+): Promise<string | undefined> {
+  if (selectedText.length > 0) return selectedText;
+  const input = await vscode.window.showInputBox({ prompt, placeHolder: fallback });
+  if (input === undefined) return undefined;
+  return input.length > 0 ? input : fallback;
+}
+
+async function applyEdit(
+  editor: vscode.TextEditor,
+  selection: vscode.Selection,
+  markdown: string
+): Promise<void> {
   await editor.edit((edit) => {
     if (selection.isEmpty) {
       edit.insert(selection.active, markdown);

--- a/src/test/suite/pasteLink.test.ts
+++ b/src/test/suite/pasteLink.test.ts
@@ -1,0 +1,134 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { classifyClipboard } from '../../insert/link';
+import { isImageExtension } from '../../insert/imageExtensions';
+
+let tmpDir: string;
+let txtFile: string;
+let pngFile: string;
+
+suite('pasteLink: classifyClipboard', () => {
+  suiteSetup(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mdfoundry-paste-link-'));
+    txtFile = path.join(tmpDir, 'note.md');
+    pngFile = path.join(tmpDir, 'pic.png');
+    fs.writeFileSync(txtFile, '# hi\n');
+    fs.writeFileSync(pngFile, '');
+  });
+
+  suiteTeardown(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('http URL → url branch', () => {
+    const r = classifyClipboard('https://example.com/foo');
+    assert.deepStrictEqual(r, { kind: 'url', value: 'https://example.com/foo' });
+  });
+
+  test('https URL with whitespace is trimmed', () => {
+    const r = classifyClipboard('  https://example.com  ');
+    assert.deepStrictEqual(r, { kind: 'url', value: 'https://example.com' });
+  });
+
+  test('empty / whitespace → none', () => {
+    assert.deepStrictEqual(classifyClipboard(''), { kind: 'none' });
+    assert.deepStrictEqual(classifyClipboard('   \n   '), { kind: 'none' });
+  });
+
+  test('absolute path that exists → path branch (non-image)', () => {
+    const r = classifyClipboard(txtFile);
+    assert.strictEqual(r.kind, 'path');
+    if (r.kind === 'path') {
+      assert.strictEqual(r.absPath, txtFile);
+      assert.strictEqual(r.isImage, false);
+    }
+  });
+
+  test('absolute path with .png extension → path branch with isImage=true', () => {
+    const r = classifyClipboard(pngFile);
+    assert.strictEqual(r.kind, 'path');
+    if (r.kind === 'path') {
+      assert.strictEqual(r.isImage, true);
+    }
+  });
+
+  test('non-existent absolute path → none', () => {
+    const fake = path.join(tmpDir, 'does-not-exist.md');
+    assert.deepStrictEqual(classifyClipboard(fake), { kind: 'none' });
+  });
+
+  test('file:// URI on POSIX resolves to a path that exists', () => {
+    if (process.platform === 'win32') return;
+    const uri = 'file://' + txtFile;
+    const r = classifyClipboard(uri, { platform: 'linux' });
+    assert.strictEqual(r.kind, 'path');
+    if (r.kind === 'path') assert.strictEqual(r.absPath, txtFile);
+  });
+
+  test('file:// URI on Windows strips the leading slash before the drive letter', () => {
+    const seen: string[] = [];
+    const fakeExists = (p: string) => {
+      seen.push(p);
+      return p === 'C:\\Users\\me\\notes\\spec.md';
+    };
+    const r = classifyClipboard('file:///C:/Users/me/notes/spec.md', {
+      platform: 'win32',
+      existsSync: fakeExists
+    });
+    assert.strictEqual(r.kind, 'path');
+    if (r.kind === 'path') {
+      assert.strictEqual(r.absPath, 'C:\\Users\\me\\notes\\spec.md');
+    }
+  });
+
+  test('file:// URI with percent-encoded spaces is decoded', () => {
+    const target = path.join(tmpDir, 'has space.md');
+    fs.writeFileSync(target, '');
+    try {
+      const uri = process.platform === 'win32'
+        ? 'file:///' + target.replace(/\\/g, '/').replace(/ /g, '%20')
+        : 'file://' + target.replace(/ /g, '%20');
+      const r = classifyClipboard(uri);
+      assert.strictEqual(r.kind, 'path');
+      if (r.kind === 'path') assert.strictEqual(r.absPath, target);
+    } finally {
+      fs.rmSync(target, { force: true });
+    }
+  });
+
+  test('relative path (even if existent) → none', () => {
+    const r = classifyClipboard('./note.md');
+    assert.strictEqual(r.kind, 'none');
+  });
+
+  test('plain word → none', () => {
+    assert.deepStrictEqual(classifyClipboard('hello world'), { kind: 'none' });
+  });
+
+  test('malformed file:// URI → none', () => {
+    const r = classifyClipboard('file://');
+    assert.strictEqual(r.kind, 'none');
+  });
+});
+
+suite('pasteLink: isImageExtension', () => {
+  test('common image extensions return true', () => {
+    assert.strictEqual(isImageExtension('foo.png'), true);
+    assert.strictEqual(isImageExtension('foo.JPG'), true);
+    assert.strictEqual(isImageExtension('foo.jpeg'), true);
+    assert.strictEqual(isImageExtension('foo.gif'), true);
+    assert.strictEqual(isImageExtension('foo.webp'), true);
+    assert.strictEqual(isImageExtension('foo.svg'), true);
+    assert.strictEqual(isImageExtension('foo.bmp'), true);
+    assert.strictEqual(isImageExtension('foo.ico'), true);
+  });
+
+  test('non-image extensions return false', () => {
+    assert.strictEqual(isImageExtension('foo.md'), false);
+    assert.strictEqual(isImageExtension('foo.txt'), false);
+    assert.strictEqual(isImageExtension('foo'), false);
+    assert.strictEqual(isImageExtension('.gitignore'), false);
+  });
+});


### PR DESCRIPTION
## Summary

- \`pasteLink\` now accepts URLs (existing), absolute file paths, and \`file://\` URIs.
- File paths must exist (existence check) so typos don't insert dead links.
- Image extensions (\`.png\`/\`.jpg\`/\`.jpeg\`/\`.gif\`/\`.webp\`/\`.svg\`/\`.bmp\`/\`.ico\`) inserted as \`![alt](rel)\`; everything else as \`[text](rel)\`.
- Selection-as-link-text behavior preserved (no prompt when selection is non-empty).
- New shared \`src/insert/imageExtensions.ts\` module — same predicate the upcoming Insert Link to File command (#70) will reuse.
- Pure \`classifyClipboard\` helper exposed for testing; 14 new unit tests cover URL, absolute path (real and non-existent), \`file://\` URI on POSIX and Windows (with drive-letter strip), percent-decoded spaces, malformed input, and isImageExtension.

## Notes

- POSIX vs Windows paths in tests: classifyClipboard accepts an injectable \`platform\` and \`existsSync\` so the Windows branch can be exercised on a Linux CI runner without conditional skips.
- \`file://\` with a pathname of just \`/\` (e.g. raw \`file://\` clipboard) → falls through to \`none\` rather than resolving to the filesystem root, which would otherwise pass the existence check on Windows.

Closes #69