### PR TITLE
add insert-link-to-file command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Added
+
+- `Insert Link to File` command — pick any workspace file from a quick-pick (current-folder-first, alphabetical) and insert a relative-path link at the cursor. Image files become `![alt](path)`, everything else `[text](path)`; selection (when present) is used as the link text. Palette-only ([#85](https://github.com/dvlprlife/Markdown-Foundry/pull/85)).
+
 ### Changed
 
 - `Paste Link` now also accepts absolute file paths and `file://` URIs from the clipboard, inserting them as relative-path links. Image extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`, `.ico`) are inserted as `![alt](path)`; everything else as `[text](path)`. Non-existent paths are rejected so typos don't sneak in. ([#84](https://github.com/dvlprlife/Markdown-Foundry/pull/84))

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Markdown Foundry combines fast table editing with one-keystroke Markdown formatt
 
 - **Paste Link** — Insert a Markdown link from the clipboard. Accepts URLs (`https://...`), absolute file paths, and `file://` URIs. URLs and non-image files become `[text](...)`; image files become `![alt](...)`. With a selection, uses it as the link text; otherwise prompts (default = basename for files, URL for URLs).
 - **Paste Image** — Save the clipboard image to a configurable folder and insert a Markdown image reference. On Linux, requires `xclip` (X11) or `wl-clipboard` (Wayland) to be installed.
+- **Insert Link to File** — Browse workspace files in a quick-pick and insert a relative-path link at the cursor. Image files become `![alt](path)`, others become `[text](path)`. With a selection, uses it as the link text.
 
 ### Formatting
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
       { "command": "markdownFoundry.nextRow",                 "title": "Next Row",                  "category": "Markdown Foundry" },
       { "command": "markdownFoundry.pasteLink",               "title": "Paste Link",                "category": "Markdown Foundry" },
       { "command": "markdownFoundry.pasteImage",              "title": "Paste Image",               "category": "Markdown Foundry" },
+      { "command": "markdownFoundry.insertLinkToFile",        "title": "Insert Link to File",       "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleBold",              "title": "Toggle Bold",               "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleItalic",            "title": "Toggle Italic",             "category": "Markdown Foundry" },
       { "command": "markdownFoundry.toggleBoldItalic",        "title": "Toggle Bold+Italic",        "category": "Markdown Foundry" },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { insertTableCommand } from './insert/insertTable';
 import { upsertTOCCommand } from './structure/commands/toc';
 import { pasteLinkCommand } from './insert/link';
 import { pasteImageCommand } from './insert/image';
+import { insertLinkToFileCommand } from './insert/linkToFile';
 import {
   toggleBoldCommand,
   toggleItalicCommand,
@@ -73,8 +74,9 @@ export function activate(context: vscode.ExtensionContext): void {
   register('markdownFoundry.nextRow',      nextRowCommand);
 
   // Insertion
-  register('markdownFoundry.pasteLink',  pasteLinkCommand);
-  register('markdownFoundry.pasteImage', pasteImageCommand);
+  register('markdownFoundry.pasteLink',         pasteLinkCommand);
+  register('markdownFoundry.pasteImage',        pasteImageCommand);
+  register('markdownFoundry.insertLinkToFile',  insertLinkToFileCommand);
 
   // Formatting toggles
   register('markdownFoundry.toggleBold',          toggleBoldCommand);

--- a/src/insert/linkToFile.ts
+++ b/src/insert/linkToFile.ts
@@ -1,0 +1,108 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { isImageExtension } from './imageExtensions';
+
+const MAX_RESULTS = 5000;
+
+export function toRelativeForwardSlash(
+  fromDocPath: string,
+  toFsPath: string,
+  pathMod: typeof path = path
+): string {
+  const rel = pathMod.relative(pathMod.dirname(fromDocPath), toFsPath);
+  return rel.split(pathMod.sep).join('/');
+}
+
+export function defaultLinkText(fsPath: string): string {
+  return path.basename(fsPath, path.extname(fsPath));
+}
+
+export interface SortableItem {
+  fsPath: string;
+  relPath: string;
+}
+
+export function sortFileItems<T extends SortableItem>(items: T[], currentDir: string): T[] {
+  const decorated = items.map((item, idx) => ({
+    item,
+    idx,
+    sameFolder: path.dirname(item.fsPath) === currentDir
+  }));
+  decorated.sort((a, b) => {
+    if (a.sameFolder !== b.sameFolder) return a.sameFolder ? -1 : 1;
+    const cmp = a.item.relPath.localeCompare(b.item.relPath, undefined, { sensitivity: 'base' });
+    if (cmp !== 0) return cmp;
+    return a.idx - b.idx;
+  });
+  return decorated.map((d) => d.item);
+}
+
+export function formatInsertion(text: string, relPath: string, isImage: boolean): string {
+  return isImage ? `![${text}](${relPath})` : `[${text}](${relPath})`;
+}
+
+interface FileQuickPickItem extends vscode.QuickPickItem {
+  fsPath: string;
+  relPath: string;
+}
+
+export async function insertLinkToFileCommand(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return;
+
+  const document = editor.document;
+  if (document.isUntitled || document.uri.scheme !== 'file') {
+    vscode.window.showInformationMessage(
+      'Markdown Foundry: Insert Link to File requires a saved file.'
+    );
+    return;
+  }
+
+  const uris = await vscode.workspace.findFiles('**/*', undefined, MAX_RESULTS);
+  if (uris.length === 0) {
+    vscode.window.showInformationMessage(
+      'Markdown Foundry: no files found in the workspace.'
+    );
+    return;
+  }
+
+  const docPath = document.uri.fsPath;
+  const currentDir = path.dirname(docPath);
+  const items: FileQuickPickItem[] = uris.map((uri) => {
+    const fsPath = uri.fsPath;
+    const relPath = vscode.workspace.asRelativePath(uri, false);
+    return {
+      label: path.basename(fsPath),
+      description: relPath,
+      fsPath,
+      relPath
+    };
+  });
+  const sorted = sortFileItems(items, currentDir);
+
+  const placeHolder =
+    uris.length >= MAX_RESULTS
+      ? `Select a file to link to (showing first ${MAX_RESULTS} — use a workspace exclude to narrow)`
+      : 'Select a file to link to';
+
+  const picked = await vscode.window.showQuickPick(sorted, {
+    matchOnDescription: true,
+    placeHolder
+  });
+  if (!picked) return;
+
+  const rel = toRelativeForwardSlash(docPath, picked.fsPath);
+  const selection = editor.selection;
+  const text = selection.isEmpty
+    ? defaultLinkText(picked.fsPath)
+    : document.getText(selection);
+  const markdown = formatInsertion(text, rel, isImageExtension(picked.fsPath));
+
+  await editor.edit((edit) => {
+    if (selection.isEmpty) {
+      edit.insert(selection.active, markdown);
+    } else {
+      edit.replace(selection, markdown);
+    }
+  });
+}

--- a/src/test/suite/linkToFile.test.ts
+++ b/src/test/suite/linkToFile.test.ts
@@ -1,0 +1,113 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import {
+  defaultLinkText,
+  formatInsertion,
+  sortFileItems,
+  toRelativeForwardSlash
+} from '../../insert/linkToFile';
+
+suite('linkToFile: toRelativeForwardSlash', () => {
+  test('sibling file under POSIX', () => {
+    const result = toRelativeForwardSlash('/proj/a.md', '/proj/b.md', path.posix);
+    assert.strictEqual(result, 'b.md');
+  });
+
+  test('subfolder under POSIX', () => {
+    const result = toRelativeForwardSlash('/proj/a.md', '/proj/sub/b.md', path.posix);
+    assert.strictEqual(result, 'sub/b.md');
+  });
+
+  test('parent folder under POSIX', () => {
+    const result = toRelativeForwardSlash('/proj/sub/a.md', '/proj/b.md', path.posix);
+    assert.strictEqual(result, '../b.md');
+  });
+
+  test('Windows path uses forward slashes in output', () => {
+    const result = toRelativeForwardSlash(
+      'C:\\proj\\notes\\a.md',
+      'C:\\proj\\images\\b.png',
+      path.win32
+    );
+    assert.strictEqual(result, '../images/b.png');
+  });
+
+  test('Windows sibling file', () => {
+    const result = toRelativeForwardSlash(
+      'C:\\proj\\a.md',
+      'C:\\proj\\b.md',
+      path.win32
+    );
+    assert.strictEqual(result, 'b.md');
+  });
+});
+
+suite('linkToFile: defaultLinkText', () => {
+  test('strips extension', () => {
+    assert.strictEqual(defaultLinkText('/proj/foo.md'), 'foo');
+  });
+
+  test('preserves multi-dot stems', () => {
+    assert.strictEqual(defaultLinkText('/proj/archive.tar.gz'), 'archive.tar');
+  });
+
+  test('dotfile keeps its name', () => {
+    assert.strictEqual(defaultLinkText('/proj/.gitignore'), '.gitignore');
+  });
+
+  test('no extension returns full basename', () => {
+    assert.strictEqual(defaultLinkText('/proj/Makefile'), 'Makefile');
+  });
+});
+
+suite('linkToFile: sortFileItems', () => {
+  test('current-folder items precede other items', () => {
+    const items = [
+      { fsPath: '/proj/sub/a.md', relPath: 'sub/a.md' },
+      { fsPath: '/proj/b.md', relPath: 'b.md' },
+      { fsPath: '/proj/sub/b.md', relPath: 'sub/b.md' },
+      { fsPath: '/proj/a.md', relPath: 'a.md' }
+    ];
+    const sorted = sortFileItems(items, '/proj');
+    assert.deepStrictEqual(
+      sorted.map((i) => i.relPath),
+      ['a.md', 'b.md', 'sub/a.md', 'sub/b.md']
+    );
+  });
+
+  test('within each group, alphabetical case-insensitive', () => {
+    const items = [
+      { fsPath: '/proj/Z.md', relPath: 'Z.md' },
+      { fsPath: '/proj/a.md', relPath: 'a.md' },
+      { fsPath: '/proj/B.md', relPath: 'B.md' }
+    ];
+    const sorted = sortFileItems(items, '/proj');
+    assert.deepStrictEqual(
+      sorted.map((i) => i.relPath),
+      ['a.md', 'B.md', 'Z.md']
+    );
+  });
+
+  test('stable across equal keys', () => {
+    const items = [
+      { fsPath: '/x/a.md', relPath: 'first' },
+      { fsPath: '/x/b.md', relPath: 'first' },
+      { fsPath: '/x/c.md', relPath: 'first' }
+    ];
+    const sorted = sortFileItems(items, '/x');
+    assert.deepStrictEqual(
+      sorted.map((i) => i.fsPath),
+      ['/x/a.md', '/x/b.md', '/x/c.md']
+    );
+  });
+});
+
+suite('linkToFile: formatInsertion', () => {
+  test('non-image renders as [text](rel)', () => {
+    assert.strictEqual(formatInsertion('docs', 'sub/x.md', false), '[docs](sub/x.md)');
+  });
+
+  test('image renders as ![text](rel)', () => {
+    assert.strictEqual(formatInsertion('hero', 'images/hero.png', true), '![hero](images/hero.png)');
+  });
+});


### PR DESCRIPTION
## Summary

- New \`Insert Link to File\` command (palette-only).
- Opens a quick-pick over workspace files; matches on basename and full path; sorts current-folder-first then alphabetical (case-insensitive, stable).
- Computes a relative path with forward slashes and inserts \`[text](rel)\` — or \`![alt](rel)\` if the picked file has an image extension. Reuses the shared \`imageExtensions\` predicate added in #69.
- Selection (when non-empty) is used as the link text; otherwise the file's basename-without-extension is the default.
- Untitled / non-\`file\` scheme documents fall through to a clear info message.
- 14 new unit tests on the pure helpers (\`toRelativeForwardSlash\`, \`defaultLinkText\`, \`sortFileItems\`, \`formatInsertion\`). Windows path handling exercised on Linux CI by injecting \`path.win32\`.

## Notes

- 5000-result cap on \`findFiles\` per the issue spec; if hit, the placeHolder text suggests adding a workspace exclude. No silent truncation.
- Self-link not filtered: the picker will list the active document itself, which is harmless (produces an empty relative path) and keeps the helper logic simple.

Closes #70