### PR TITLE
Sync agent workflow docs to six review criteria

### DIFF
--- a/agents/WORKFLOW.md
+++ b/agents/WORKFLOW.md
@@ -65,7 +65,7 @@ The reviewer finds issues labeled `agent` + `status: in-review`.
 
 1. Locates the open PR referencing the issue (`Closes #{number}`)
 2. Gathers the issue body, the `## Implementation Plan` comment, the PR, and the diff
-3. Reviews against four criteria: Implementation Plan adherence, Acceptance Criteria, code quality, and CLAUDE.md compliance
+3. Reviews against six criteria: Implementation Plan adherence, Acceptance Criteria, code quality, CLAUDE.md compliance, CHANGELOG compliance, and README compliance
 4. Posts a review on the PR (request changes if findings exist, comment review otherwise — agents cannot self-approve)
 5. Posts a summary comment on the issue
 

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -74,11 +74,13 @@ gh pr review {pr_number} --repo dvlprlife/Markdown-Foundry --comment --body "...
 ```
 gh pr review {pr_number} --repo dvlprlife/Markdown-Foundry --comment --body "## Automated Review
 
-All four criteria satisfied:
+All six criteria satisfied:
 - Plan adherence: ✓
 - Acceptance criteria: ✓
 - Code quality: ✓
 - CLAUDE.md compliance: ✓
+- CHANGELOG compliance: ✓
+- README compliance: ✓
 
 Ready for human approval."
 ```


### PR DESCRIPTION
## Summary

- Update `agents/WORKFLOW.md:68` to describe the reviewer as checking six criteria (adds CHANGELOG and README to the list)
- Update `agents/pr-reviewer.md:77` clean-PR success template to "All six criteria satisfied" with ✓ lines for CHANGELOG and README

Docs-only sync — `pr-reviewer.md` Step 4 already enumerated six criteria; this brings the workflow overview and the success template in line.

No CHANGELOG or README entry: contributor-facing docs only.

Closes #86