### PR TITLE
Run CI on macOS and Windows in addition to Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -18,4 +22,9 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: node esbuild.js --production
-      - run: xvfb-run -a npm test
+      - name: Run tests (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm test
+      - name: Run tests (macOS/Windows)
+        if: runner.os != 'Linux'
+        run: npm test


### PR DESCRIPTION
## Summary

- Convert the `build` job into a matrix across `ubuntu-latest`, `macos-latest`, `windows-latest`
- `fail-fast: false` so one OS failing doesn't cancel the others
- Split the test step: `xvfb-run -a npm test` on Linux, plain `npm test` on macOS/Windows (real display)

No CHANGELOG/README entry — CI workflow change, contributor-facing only.

Closes #88