### PR TITLE
Add vsce package smoke test step to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,6 @@ jobs:
       - name: Run tests (macOS/Windows)
         if: runner.os != 'Linux'
         run: npm test
+      - name: Package smoke test
+        if: runner.os == 'Linux'
+        run: npx @vscode/vsce package -o mdfoundry-ci.vsix


### PR DESCRIPTION
## Summary

- Append `npx @vscode/vsce package -o mdfoundry-ci.vsix` after the test step
- Exercises the publishable build path (calls `npm run vscode:prepublish` → `npm run package`)
- Artifact is discarded with the runner; not uploaded, not published

No CHANGELOG/README entry — CI workflow change, contributor-facing only.

Closes #89