### PR TITLE
Cancel in-progress CI runs when a PR is updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add a top-level `concurrency` block to `build.yml` grouped by workflow + ref with `cancel-in-progress: true`
- Pushing a new commit to a PR cancels the in-flight run for that ref instead of letting it finish to no signal

No CHANGELOG/README entry — CI workflow change, contributor-facing only.

Closes #90