### PR TITLE
Move misplaced JSDoc from toggleBulletItem region to toggleTaskItem

### DIFF
--- a/src/format/toggle.ts
+++ b/src/format/toggle.ts
@@ -78,11 +78,6 @@ export function adjustHeading(line: string, delta: number): string {
   return '#'.repeat(newLevel) + ' ' + m[2];
 }
 
-/**
- * Cycle a line through: plain → `- [ ] x` → `- [x] x` → `- [ ] x` → ... .
- * Preserves leading indentation. A bullet line without a checkbox (`- x`) is
- * promoted to an unchecked task (`- [ ] x`).
- */
 const BULLET_RE = /^(\s*)([-*+])\s+/;
 
 /**
@@ -130,6 +125,11 @@ export function toggleNumberedItem(text: string): string {
     .join('\n');
 }
 
+/**
+ * Cycle a line through: plain → `- [ ] x` → `- [x] x` → `- [ ] x` → ... .
+ * Preserves leading indentation. A bullet line without a checkbox (`- x`) is
+ * promoted to an unchecked task (`- [ ] x`).
+ */
 export function toggleTaskItem(line: string): string {
   const indentMatch = line.match(/^(\s*)(.*)$/);
   const indent = indentMatch ? indentMatch[1] : '';


### PR DESCRIPTION
## Summary

- Relocate the misplaced `toggleTaskItem` JSDoc block in `src/format/toggle.ts` from above `BULLET_RE` (where it was orphaned between sections) to immediately above the `toggleTaskItem` function it actually documents.
- Pure comment relocation: no logic, identifier, or behavior changes. `toggleBulletItem`'s own JSDoc is unchanged.
- No CHANGELOG or README entry: per CLAUDE.md this is a contributor-facing internal refactor with no user-visible behavior change.

Verified locally: `npx tsc --noEmit`, `node esbuild.js --production`, and `npm test` (162 passing) all pass.

Closes #96