### PR TITLE
Toggle Task List Item now applies to every line in a multi-line selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Changed
 
+- `Toggle Task List Item` now applies to every non-empty line in a multi-line selection, matching the behavior of `Toggle Bullet List` and `Toggle Numbered List`. With no selection, behavior is unchanged — the cursor's line is cycled.
 - `Paste Link` now also accepts absolute file paths and `file://` URIs from the clipboard, inserting them as relative-path links. Image extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`, `.ico`) are inserted as `![alt](path)`; everything else as `[text](path)`. Non-existent paths are rejected so typos don't sneak in. ([#84](https://github.com/dvlprlife/Markdown-Foundry/pull/84))
 
 ## [0.4.0] - 2026-05-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Changed
 
-- `Toggle Task List Item` now applies to every non-empty line in a multi-line selection, matching the behavior of `Toggle Bullet List` and `Toggle Numbered List`. With no selection, behavior is unchanged — the cursor's line is cycled.
+- `Toggle Task List Item` now applies to every non-empty line in a multi-line selection, matching the behavior of `Toggle Bullet List` and `Toggle Numbered List`. With no selection, behavior is unchanged — the cursor's line is cycled. ([#99](https://github.com/dvlprlife/Markdown-Foundry/pull/99))
 - `Paste Link` now also accepts absolute file paths and `file://` URIs from the clipboard, inserting them as relative-path links. Image extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`, `.ico`) are inserted as `![alt](path)`; everything else as `[text](path)`. Non-existent paths are rejected so typos don't sneak in. ([#84](https://github.com/dvlprlife/Markdown-Foundry/pull/84))
 
 ## [0.4.0] - 2026-05-02

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Markdown Foundry combines fast table editing with one-keystroke Markdown formatt
 
   ![Toggle, promote, and demote headings](images/demo/heading.gif)
 
-- **Toggle task list item** — cycle the current line through plain → `- [ ] todo` → `- [x] done` → `- [ ] todo` …, preserving leading indentation.
+- **Toggle task list item** — cycle every line in the selection (or the current line if none) through plain → `- [ ] todo` → `- [x] done` → `- [ ] todo` …, preserving leading indentation.
 
   ![Toggle a task list item between plain, unchecked, and checked](images/demo/tasklist.gif)
 - **Insert horizontal rule** — drop a `---` line below the cursor's current line.

--- a/src/format/commands.ts
+++ b/src/format/commands.ts
@@ -141,7 +141,7 @@ export async function demoteHeadingCommand(): Promise<void> {
 }
 
 export async function toggleTaskListCommand(): Promise<void> {
-  await applyCurrentLine(toggleTaskItem);
+  await applyLineRange(toggleTaskItem);
 }
 
 export async function insertHorizontalRuleCommand(): Promise<void> {

--- a/src/format/toggle.ts
+++ b/src/format/toggle.ts
@@ -126,11 +126,18 @@ export function toggleNumberedItem(text: string): string {
 }
 
 /**
- * Cycle a line through: plain → `- [ ] x` → `- [x] x` → `- [ ] x` → ... .
- * Preserves leading indentation. A bullet line without a checkbox (`- x`) is
- * promoted to an unchecked task (`- [ ] x`).
+ * Cycle each non-empty line through: plain → `- [ ] x` → `- [x] x` → `- [ ] x`
+ * → ... . Preserves leading indentation. A bullet line without a checkbox
+ * (`- x`) is promoted to an unchecked task (`- [ ] x`). Empty lines pass
+ * through unchanged.
  */
-export function toggleTaskItem(line: string): string {
+export function toggleTaskItem(text: string): string {
+  return text.split(/\r?\n/).map(toggleTaskLine).join('\n');
+}
+
+function toggleTaskLine(line: string): string {
+  if (line === '') return line;
+
   const indentMatch = line.match(/^(\s*)(.*)$/);
   const indent = indentMatch ? indentMatch[1] : '';
   const body = indentMatch ? indentMatch[2] : line;
@@ -142,6 +149,6 @@ export function toggleTaskItem(line: string): string {
   if (unchecked) return `${indent}- [x] ${unchecked[1]}`;
 
   const bullet = body.match(/^-\s+(.*)$/);
-  const text = bullet ? bullet[1] : body;
-  return `${indent}- [ ] ${text}`;
+  const bodyText = bullet ? bullet[1] : body;
+  return `${indent}- [ ] ${bodyText}`;
 }

--- a/src/test/suite/toggle.test.ts
+++ b/src/test/suite/toggle.test.ts
@@ -189,6 +189,27 @@ suite('format: toggleTaskItem', () => {
     assert.strictEqual(toggleTaskItem('  - [ ] do laundry'), '  - [x] do laundry');
     assert.strictEqual(toggleTaskItem('  - [x] do laundry'), '  - [ ] do laundry');
   });
+
+  test('multi-line plain → all become unchecked tasks', () => {
+    assert.strictEqual(
+      toggleTaskItem('one\ntwo\nthree'),
+      '- [ ] one\n- [ ] two\n- [ ] three'
+    );
+  });
+
+  test('multi-line mixed (plain / unchecked / checked) → each line cycles independently', () => {
+    assert.strictEqual(
+      toggleTaskItem('plain\n- [ ] todo\n- [x] done'),
+      '- [ ] plain\n- [x] todo\n- [ ] done'
+    );
+  });
+
+  test('empty lines inside a multi-line block pass through unchanged', () => {
+    assert.strictEqual(
+      toggleTaskItem('first\n\nthird'),
+      '- [ ] first\n\n- [ ] third'
+    );
+  });
 });
 
 suite('format: toggleBulletItem', () => {


### PR DESCRIPTION
## Summary

- `toggleTaskListCommand` switches from `applyCurrentLine` to `applyLineRange` so a multi-line selection cycles every line, matching `Toggle Bullet List` / `Toggle Numbered List`.
- `toggleTaskItem` now splits/maps/joins multi-line input internally; empty lines pass through unchanged.
- Adds three test cases for multi-line plain, mixed (plain/`[ ]`/`[x]`), and blank-line preservation.
- README "Toggle task list item" reworded; CHANGELOG `[Unreleased] ### Changed` notes the new behavior.

Closes #98