### PR TITLE
Add editor context submenu for Markdown Foundry commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Added
 
-- Editor context submenu listing all Markdown Foundry commands, grouped by Inline / Block / Heading / Insert / Table; the Table group only appears when the cursor is inside a table.
+- Editor context submenu listing all Markdown Foundry commands, grouped by Inline / Block / Heading / Insert / Table; the Table group only appears when the cursor is inside a table ([#100](https://github.com/dvlprlife/Markdown-Foundry/pull/100)).
 - `Insert Link to File` command — pick any workspace file from a quick-pick (current-folder-first, alphabetical) and insert a relative-path link at the cursor. Image files become `![alt](path)`, everything else `[text](path)`; selection (when present) is used as the link text. Palette-only ([#85](https://github.com/dvlprlife/Markdown-Foundry/pull/85)).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Added
 
+- Editor context submenu listing all Markdown Foundry commands, grouped by Inline / Block / Heading / Insert / Table; the Table group only appears when the cursor is inside a table.
 - `Insert Link to File` command — pick any workspace file from a quick-pick (current-folder-first, alphabetical) and insert a relative-path link at the cursor. Image files become `![alt](path)`, everything else `[text](path)`; selection (when present) is used as the link text. Palette-only ([#85](https://github.com/dvlprlife/Markdown-Foundry/pull/85)).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Markdown Foundry combines fast table editing with one-keystroke Markdown formatt
 | `Ctrl+B` / `Cmd+B` | Toggle bold (when editing a Markdown file) |
 | `Ctrl+I` / `Cmd+I` | Toggle italic (when editing a Markdown file) |
 
-All other commands are available through the Command Palette (search for "Markdown Foundry").
+All other commands are available through the Command Palette (search for "Markdown Foundry") or by right-clicking inside a Markdown file — every command lives under a `Markdown Foundry` submenu, grouped into Inline, Block, Heading, Insert, and (when the cursor is in a table) Table sections.
 
 ## Settings
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,63 @@
         "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
       }
     ],
+    "submenus": [
+      {
+        "id": "markdownFoundry.editorContext",
+        "label": "Markdown Foundry"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "submenu": "markdownFoundry.editorContext",
+          "group": "markdownFoundry@1",
+          "when": "editorLangId == markdown"
+        }
+      ],
+      "markdownFoundry.editorContext": [
+        { "command": "markdownFoundry.toggleBold",          "group": "1_inline@1" },
+        { "command": "markdownFoundry.toggleItalic",        "group": "1_inline@2" },
+        { "command": "markdownFoundry.toggleBoldItalic",    "group": "1_inline@3" },
+        { "command": "markdownFoundry.toggleStrikethrough", "group": "1_inline@4" },
+        { "command": "markdownFoundry.toggleInlineCode",    "group": "1_inline@5" },
+
+        { "command": "markdownFoundry.toggleBlockquote",    "group": "2_block@1" },
+        { "command": "markdownFoundry.toggleBlockCode",     "group": "2_block@2" },
+        { "command": "markdownFoundry.toggleBulletList",    "group": "2_block@3" },
+        { "command": "markdownFoundry.toggleNumberedList",  "group": "2_block@4" },
+        { "command": "markdownFoundry.toggleTaskList",      "group": "2_block@5" },
+
+        { "command": "markdownFoundry.toggleHeading1",      "group": "3_heading@1" },
+        { "command": "markdownFoundry.toggleHeading2",      "group": "3_heading@2" },
+        { "command": "markdownFoundry.toggleHeading3",      "group": "3_heading@3" },
+        { "command": "markdownFoundry.toggleHeading4",      "group": "3_heading@4" },
+        { "command": "markdownFoundry.toggleHeading5",      "group": "3_heading@5" },
+        { "command": "markdownFoundry.toggleHeading6",      "group": "3_heading@6" },
+        { "command": "markdownFoundry.promoteHeading",      "group": "3_heading@7" },
+        { "command": "markdownFoundry.demoteHeading",       "group": "3_heading@8" },
+
+        { "command": "markdownFoundry.insertHorizontalRule","group": "4_insert@1" },
+        { "command": "markdownFoundry.insertLinkToFile",    "group": "4_insert@2" },
+        { "command": "markdownFoundry.pasteLink",           "group": "4_insert@3" },
+        { "command": "markdownFoundry.pasteImage",          "group": "4_insert@4" },
+        { "command": "markdownFoundry.insertTable",         "group": "4_insert@5" },
+        { "command": "markdownFoundry.toc",                 "group": "4_insert@6" },
+
+        { "command": "markdownFoundry.alignTable",          "group": "5_table@1",  "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.insertRowAbove",      "group": "5_table@2",  "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.insertRowBelow",      "group": "5_table@3",  "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.insertColumnLeft",    "group": "5_table@4",  "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.insertColumnRight",   "group": "5_table@5",  "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.deleteRow",           "group": "5_table@6",  "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.deleteColumn",        "group": "5_table@7",  "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.moveRowUp",           "group": "5_table@8",  "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.moveRowDown",         "group": "5_table@9",  "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.moveColumnLeft",      "group": "5_table@10", "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.moveColumnRight",     "group": "5_table@11", "when": "markdownFoundry.inTable" },
+        { "command": "markdownFoundry.sortByColumn",        "group": "5_table@12", "when": "markdownFoundry.inTable" }
+      ]
+    },
     "configuration": {
       "title": "Markdown Foundry",
       "properties": {


### PR DESCRIPTION
## Summary

- Adds `contributes.submenus` (`markdownFoundry.editorContext`) and `contributes.menus` blocks to `package.json`. Right-clicking inside a Markdown file now exposes every Markdown Foundry command from a single `Markdown Foundry` submenu, grouped into Inline / Block / Heading / Insert / Table sections (group prefixes `1_…` through `5_…` produce the visual dividers).
- Table-section items are gated on `markdownFoundry.inTable`, so the entire Table group disappears when the cursor isn't in a table. The submenu mount itself is gated on `editorLangId == markdown` so it's invisible in non-Markdown files.
- Superscript / Subscript items are deferred to #94's PR — their commands don't exist yet.
- README updated to mention the right-click submenu; CHANGELOG `[Unreleased] / Added` entry added.

Manually smoke-tested in the Extension Development Host: submenu shows the four non-table sections everywhere in a `.md` file, the Table section appears only inside a table, nothing shows up in `.txt` / `.ts`.

Closes #95