### PR TITLE
Align ESLint config with the dvlprlife portfolio (errors + brace-required)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,14 +7,16 @@
   },
   "plugins": ["@typescript-eslint"],
   "rules": {
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/naming-convention": [
       "warn",
       { "selector": "import", "format": ["camelCase", "PascalCase"] }
     ],
-    "semi": "warn",
-    "curly": "off",
-    "eqeqeq": "warn",
-    "no-throw-literal": "warn"
+    "semi": ["error", "always"],
+    "curly": "error",
+    "eqeqeq": ["error", "always"],
+    "no-throw-literal": "error"
   },
   "ignorePatterns": ["dist", "node_modules", "**/*.d.ts"]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,9 +108,9 @@ export function activate(context: vscode.ExtensionContext): void {
   // Align on save (opt-in via config)
   context.subscriptions.push(
     vscode.workspace.onWillSaveTextDocument((event) => {
-      if (event.document.languageId !== 'markdown') return;
+      if (event.document.languageId !== 'markdown') {return;}
       const config = vscode.workspace.getConfiguration('markdownFoundry');
-      if (!config.get<boolean>('alignOnSave')) return;
+      if (!config.get<boolean>('alignOnSave')) {return;}
       event.waitUntil(Promise.resolve(alignAllTablesInDocument(event.document)));
     })
   );

--- a/src/format/commands.ts
+++ b/src/format/commands.ts
@@ -16,7 +16,7 @@ import {
  */
 async function applyInline(marker: string): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
   const selection = editor.selection;
 
   if (selection.isEmpty) {
@@ -58,7 +58,7 @@ async function applyLineRange(
   transform: (text: string) => string
 ): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
   const selection = editor.selection;
 
   const startLine = selection.start.line;
@@ -97,7 +97,7 @@ async function applyCurrentLine(
   transform: (line: string) => string
 ): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
   const cursorLine = editor.selection.active.line;
   const line = editor.document.lineAt(cursorLine);
   const replaced = transform(line.text);
@@ -146,7 +146,7 @@ export async function toggleTaskListCommand(): Promise<void> {
 
 export async function insertHorizontalRuleCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
   const cursorLine = editor.selection.active.line;
   const line = editor.document.lineAt(cursorLine);
   const insertPos = new vscode.Position(cursorLine, line.text.length);

--- a/src/format/toggle.ts
+++ b/src/format/toggle.ts
@@ -72,9 +72,9 @@ export function wrapHeading(line: string, level: number): string {
  */
 export function adjustHeading(line: string, delta: number): string {
   const m = line.match(/^(#{1,6})\s+(.*)$/);
-  if (!m) return line;
+  if (!m) {return line;}
   const newLevel = m[1].length + delta;
-  if (newLevel < 1 || newLevel > 6) return line;
+  if (newLevel < 1 || newLevel > 6) {return line;}
   return '#'.repeat(newLevel) + ' ' + m[2];
 }
 
@@ -116,7 +116,7 @@ export function toggleNumberedItem(text: string): string {
   let n = 1;
   return lines
     .map((l) => {
-      if (l === '') return l;
+      if (l === '') {return l;}
       const m = l.match(/^(\s*)(.*)$/);
       const indent = m ? m[1] : '';
       const body = m ? m[2] : l;
@@ -136,17 +136,17 @@ export function toggleTaskItem(text: string): string {
 }
 
 function toggleTaskLine(line: string): string {
-  if (line === '') return line;
+  if (line === '') {return line;}
 
   const indentMatch = line.match(/^(\s*)(.*)$/);
   const indent = indentMatch ? indentMatch[1] : '';
   const body = indentMatch ? indentMatch[2] : line;
 
   const checked = body.match(/^-\s+\[x\]\s+(.*)$/i);
-  if (checked) return `${indent}- [ ] ${checked[1]}`;
+  if (checked) {return `${indent}- [ ] ${checked[1]}`;}
 
   const unchecked = body.match(/^-\s+\[ \]\s+(.*)$/);
-  if (unchecked) return `${indent}- [x] ${unchecked[1]}`;
+  if (unchecked) {return `${indent}- [x] ${unchecked[1]}`;}
 
   const bullet = body.match(/^-\s+(.*)$/);
   const bodyText = bullet ? bullet[1] : body;

--- a/src/insert/image.ts
+++ b/src/insert/image.ts
@@ -10,7 +10,7 @@ const execFileAsync = promisify(execFile);
 // out to a platform-specific helper.
 export async function pasteImageCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
 
   const document = editor.document;
   if (document.uri.scheme !== 'file') {
@@ -196,8 +196,8 @@ async function runAndCapture(
 function readStderr(err: unknown): string {
   if (typeof err === 'object' && err !== null && 'stderr' in err) {
     const stderr = (err as { stderr: unknown }).stderr;
-    if (typeof stderr === 'string') return stderr;
-    if (Buffer.isBuffer(stderr)) return stderr.toString();
+    if (typeof stderr === 'string') {return stderr;}
+    if (Buffer.isBuffer(stderr)) {return stderr.toString();}
   }
   return '';
 }

--- a/src/insert/insertTable.ts
+++ b/src/insert/insertTable.ts
@@ -53,11 +53,11 @@ export function validateDimension(
   max: number
 ): string | undefined {
   const trimmed = input.trim();
-  if (trimmed.length === 0) return `${label} is required`;
-  if (!/^-?\d+$/.test(trimmed)) return `${label} must be a whole number`;
+  if (trimmed.length === 0) {return `${label} is required`;}
+  if (!/^-?\d+$/.test(trimmed)) {return `${label} must be a whole number`;}
   const n = Number(trimmed);
-  if (n < min) return `${label} must be at least ${min}`;
-  if (n > max) return `${label} must be at most ${max}`;
+  if (n < min) {return `${label} must be at least ${min}`;}
+  if (n > max) {return `${label} must be at most ${max}`;}
   return undefined;
 }
 
@@ -73,27 +73,27 @@ export function computePadding(
 }
 
 function leadingPadding(textBefore: string, eol: string): string {
-  if (textBefore.length === 0) return '';
-  if (!textBefore.endsWith(eol)) return eol + eol;
+  if (textBefore.length === 0) {return '';}
+  if (!textBefore.endsWith(eol)) {return eol + eol;}
   const beforeNewline = textBefore.slice(0, -eol.length);
-  if (beforeNewline.length === 0 || beforeNewline.endsWith(eol)) return '';
+  if (beforeNewline.length === 0 || beforeNewline.endsWith(eol)) {return '';}
   return eol;
 }
 
 function trailingPadding(textAfter: string, eol: string): string {
-  if (textAfter.length === 0) return '';
-  if (!textAfter.startsWith(eol)) return eol + eol;
+  if (textAfter.length === 0) {return '';}
+  if (!textAfter.startsWith(eol)) {return eol + eol;}
   const afterNewline = textAfter.slice(eol.length);
-  if (afterNewline.length === 0 || afterNewline.startsWith(eol)) return '';
+  if (afterNewline.length === 0 || afterNewline.startsWith(eol)) {return '';}
   return eol;
 }
 
 export async function insertTableCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
 
   const dims = await pickDimensions();
-  if (!dims) return;
+  if (!dims) {return;}
 
   const config = vscode.workspace.getConfiguration('markdownFoundry');
   const alignment = config.get<Alignment>('defaultAlignment') ?? 'left';
@@ -112,10 +112,10 @@ export async function insertTableCommand(): Promise<void> {
   const replacement = leading + body + trailing;
 
   const ok = await editor.edit((edit) => edit.replace(selection, replacement));
-  if (!ok) return;
+  if (!ok) {return;}
 
   const headerOffsetWithinBody = body.indexOf(FIRST_HEADER_LABEL);
-  if (headerOffsetWithinBody < 0) return;
+  if (headerOffsetWithinBody < 0) {return;}
   const headerStartOffset = startOffset + leading.length + headerOffsetWithinBody;
   const headerEndOffset = headerStartOffset + FIRST_HEADER_LABEL.length;
   const start = document.positionAt(headerStartOffset);
@@ -136,7 +136,7 @@ async function pickDimensions(): Promise<PresetSize | undefined> {
   const picked = await vscode.window.showQuickPick(items, {
     placeHolder: 'Table size'
   });
-  if (!picked) return undefined;
+  if (!picked) {return undefined;}
 
   if (picked.label !== customLabel) {
     const preset = PRESETS.find((p) => `${p.rows}×${p.cols}` === picked.label);
@@ -148,14 +148,14 @@ async function pickDimensions(): Promise<PresetSize | undefined> {
     value: '3',
     validateInput: (v) => validateDimension(v, 'Rows', ROW_MIN, ROW_MAX)
   });
-  if (rowsInput === undefined) return undefined;
+  if (rowsInput === undefined) {return undefined;}
 
   const colsInput = await vscode.window.showInputBox({
     prompt: `Columns (${COL_MIN}-${COL_MAX})`,
     value: '3',
     validateInput: (v) => validateDimension(v, 'Columns', COL_MIN, COL_MAX)
   });
-  if (colsInput === undefined) return undefined;
+  if (colsInput === undefined) {return undefined;}
 
   return { rows: Number(rowsInput.trim()), cols: Number(colsInput.trim()) };
 }

--- a/src/insert/link.ts
+++ b/src/insert/link.ts
@@ -20,7 +20,7 @@ export function classifyClipboard(raw: string, options: ClassifyOptions = {}): C
   const platform = options.platform ?? process.platform;
   const exists = options.existsSync ?? fs.existsSync;
   const trimmed = raw.trim();
-  if (trimmed.length === 0) return { kind: 'none' };
+  if (trimmed.length === 0) {return { kind: 'none' };}
 
   if (URL_RE.test(trimmed)) {
     return { kind: 'url', value: trimmed };
@@ -29,12 +29,12 @@ export function classifyClipboard(raw: string, options: ClassifyOptions = {}): C
   if (/^file:\/\//i.test(trimmed)) {
     try {
       const url = new NodeURL(trimmed);
-      if (url.pathname === '' || url.pathname === '/') return { kind: 'none' };
+      if (url.pathname === '' || url.pathname === '/') {return { kind: 'none' };}
       let p = decodeURIComponent(url.pathname);
       if (platform === 'win32' && /^\/[A-Za-z]:/.test(p)) {
         p = p.slice(1);
       }
-      if (platform === 'win32') p = p.replace(/\//g, '\\');
+      if (platform === 'win32') {p = p.replace(/\//g, '\\');}
       if (isAbsoluteAcross(p, platform) && exists(p)) {
         return { kind: 'path', absPath: p, isImage: isImageExtension(p) };
       }
@@ -57,7 +57,7 @@ function isAbsoluteAcross(p: string, platform: NodeJS.Platform): boolean {
 
 export async function pasteLinkCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
 
   const document = editor.document;
   const raw = await vscode.env.clipboard.readText();
@@ -80,7 +80,7 @@ export async function pasteLinkCommand(): Promise<void> {
       url,
       'Link text (leave empty to use the URL)'
     );
-    if (text === undefined) return;
+    if (text === undefined) {return;}
     await applyEdit(editor, selection, `[${text}](${url})`);
     return;
   }
@@ -101,7 +101,7 @@ export async function pasteLinkCommand(): Promise<void> {
     fallback,
     `Link text (leave empty to use ${fallback})`
   );
-  if (text === undefined) return;
+  if (text === undefined) {return;}
 
   const markdown = result.isImage ? `![${text}](${rel})` : `[${text}](${rel})`;
   await applyEdit(editor, selection, markdown);
@@ -112,9 +112,9 @@ async function resolveLinkText(
   fallback: string,
   prompt: string
 ): Promise<string | undefined> {
-  if (selectedText.length > 0) return selectedText;
+  if (selectedText.length > 0) {return selectedText;}
   const input = await vscode.window.showInputBox({ prompt, placeHolder: fallback });
-  if (input === undefined) return undefined;
+  if (input === undefined) {return undefined;}
   return input.length > 0 ? input : fallback;
 }
 

--- a/src/insert/linkToFile.ts
+++ b/src/insert/linkToFile.ts
@@ -29,9 +29,9 @@ export function sortFileItems<T extends SortableItem>(items: T[], currentDir: st
     sameFolder: path.dirname(item.fsPath) === currentDir
   }));
   decorated.sort((a, b) => {
-    if (a.sameFolder !== b.sameFolder) return a.sameFolder ? -1 : 1;
+    if (a.sameFolder !== b.sameFolder) {return a.sameFolder ? -1 : 1;}
     const cmp = a.item.relPath.localeCompare(b.item.relPath, undefined, { sensitivity: 'base' });
-    if (cmp !== 0) return cmp;
+    if (cmp !== 0) {return cmp;}
     return a.idx - b.idx;
   });
   return decorated.map((d) => d.item);
@@ -48,7 +48,7 @@ interface FileQuickPickItem extends vscode.QuickPickItem {
 
 export async function insertLinkToFileCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
 
   const document = editor.document;
   if (document.isUntitled || document.uri.scheme !== 'file') {
@@ -89,7 +89,7 @@ export async function insertLinkToFileCommand(): Promise<void> {
     matchOnDescription: true,
     placeHolder
   });
-  if (!picked) return;
+  if (!picked) {return;}
 
   const rel = toRelativeForwardSlash(docPath, picked.fsPath);
   const selection = editor.selection;

--- a/src/structure/commands/toc.ts
+++ b/src/structure/commands/toc.ts
@@ -8,7 +8,7 @@ import {
 
 export async function upsertTOCCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
 
   const document = editor.document;
   const text = document.getText();

--- a/src/structure/toc.ts
+++ b/src/structure/toc.ts
@@ -35,7 +35,7 @@ export function extractHeadings(text: string): Heading[] {
     let line = raw;
     if (inHtmlComment) {
       const closeIdx = line.indexOf('-->');
-      if (closeIdx < 0) continue;
+      if (closeIdx < 0) {continue;}
       line = line.slice(closeIdx + 3);
       inHtmlComment = false;
     }
@@ -55,7 +55,7 @@ export function extractHeadings(text: string): Heading[] {
     }
 
     const m = lineToScan.match(HEADING_RE);
-    if (!m) continue;
+    if (!m) {continue;}
     const level = m[1].length;
     const text = m[2];
     const slug = slugify(text);
@@ -96,10 +96,10 @@ export function slugify(text: string): string {
 export function dedupeSlugs(headings: Heading[]): Heading[] {
   const seen = new Map<string, number>();
   return headings.map((h) => {
-    if (h.slug === '') return h;
+    if (h.slug === '') {return h;}
     const count = seen.get(h.slug) ?? 0;
     seen.set(h.slug, count + 1);
-    if (count === 0) return h;
+    if (count === 0) {return h;}
     return { ...h, slug: `${h.slug}-${count}` };
   });
 }
@@ -119,7 +119,7 @@ export function generateTOC(headings: Heading[], options: TOCOptions): string {
     return `${indent.repeat(depth)}- [${h.text}](#${h.slug})`;
   });
   const body = lines.join('\n');
-  if (!options.includeMarkers) return body;
+  if (!options.includeMarkers) {return body;}
   return `${TOC_OPEN_MARKER}\n${body}\n${TOC_CLOSE_MARKER}`;
 }
 
@@ -130,9 +130,9 @@ export interface TOCRange {
 
 export function locateExistingTOC(text: string): TOCRange | undefined {
   const startOffset = text.indexOf(TOC_OPEN_MARKER);
-  if (startOffset < 0) return undefined;
+  if (startOffset < 0) {return undefined;}
   const endSearchFrom = startOffset + TOC_OPEN_MARKER.length;
   const endOffset = text.indexOf(TOC_CLOSE_MARKER, endSearchFrom);
-  if (endOffset < 0) return undefined;
+  if (endOffset < 0) {return undefined;}
   return { startOffset, endOffset: endOffset + TOC_CLOSE_MARKER.length };
 }

--- a/src/table/commands/convert.ts
+++ b/src/table/commands/convert.ts
@@ -15,7 +15,7 @@ import { formatTable } from '../formatter';
  */
 export async function convertSelectionToTableCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
 
   const selection = editor.selection;
   if (selection.isEmpty) {
@@ -33,7 +33,7 @@ export async function convertSelectionToTableCommand(): Promise<void> {
     const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
     grid = lines.map((line) => splitLine(line, delimiter));
   }
-  if (grid.length === 0) return;
+  if (grid.length === 0) {return;}
   const columnCount = Math.max(...grid.map((row) => row.length));
   const normalized = grid.map((row) =>
     row.length === columnCount ? row : [...row, ...Array(columnCount - row.length).fill('')]
@@ -64,8 +64,8 @@ export async function convertSelectionToTableCommand(): Promise<void> {
 type Delimiter = 'tab' | 'comma' | 'whitespace';
 
 function detectDelimiter(text: string): Delimiter {
-  if (text.includes('\t')) return 'tab';
-  if (text.includes(',')) return 'comma';
+  if (text.includes('\t')) {return 'tab';}
+  if (text.includes(',')) {return 'comma';}
   return 'whitespace';
 }
 

--- a/src/table/commands/navigate.ts
+++ b/src/table/commands/navigate.ts
@@ -9,14 +9,14 @@ import { formatTable } from '../formatter';
  */
 export async function nextCellCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
   const document = editor.document;
   const cursorLine = editor.selection.active.line;
   const location = locateTable(document, cursorLine);
-  if (!location) return;
+  if (!location) {return;}
 
   const coords = cursorToTableCoords(document, location, editor.selection.active);
-  if (!coords) return;
+  if (!coords) {return;}
 
   const model = parseTable(document, location);
   const columnCount = model.headers.length;
@@ -43,14 +43,14 @@ export async function nextCellCommand(): Promise<void> {
 
 export async function previousCellCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
   const document = editor.document;
   const cursorLine = editor.selection.active.line;
   const location = locateTable(document, cursorLine);
-  if (!location) return;
+  if (!location) {return;}
 
   const coords = cursorToTableCoords(document, location, editor.selection.active);
-  if (!coords) return;
+  if (!coords) {return;}
 
   const model = parseTable(document, location);
 
@@ -60,7 +60,7 @@ export async function previousCellCommand(): Promise<void> {
   if (targetCol < 0) {
     targetCol = model.headers.length - 1;
     targetRow = targetRow - 1;
-    if (targetRow < -1) return;
+    if (targetRow < -1) {return;}
   }
 
   await moveCursorToCell(location.headerLine, targetRow, targetCol);
@@ -72,14 +72,14 @@ export async function previousCellCommand(): Promise<void> {
  */
 export async function nextRowCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
   const document = editor.document;
   const cursorLine = editor.selection.active.line;
   const location = locateTable(document, cursorLine);
-  if (!location) return;
+  if (!location) {return;}
 
   const coords = cursorToTableCoords(document, location, editor.selection.active);
-  if (!coords) return;
+  if (!coords) {return;}
 
   const model = parseTable(document, location);
   const columnCount = model.headers.length;
@@ -106,18 +106,18 @@ async function moveCursorToCell(
   columnIndex: number
 ): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
   const document = editor.document;
 
   // rowIndex: -1 = header, 0+ = body (offset by 2 to skip separator)
   const lineNumber =
     rowIndex === -1 ? headerLine : headerLine + 2 + rowIndex;
 
-  if (lineNumber >= document.lineCount) return;
+  if (lineNumber >= document.lineCount) {return;}
   const lineText = document.lineAt(lineNumber).text;
 
   const range = computeCellRange(lineText, columnIndex);
-  if (!range) return;
+  if (!range) {return;}
 
   const anchor = new vscode.Position(lineNumber, range.start);
   const active = new vscode.Position(lineNumber, range.end);
@@ -156,11 +156,11 @@ export function computeCellRange(
     }
   }
 
-  if (startPos === -1) return undefined;
-  if (endPos === -1) endPos = lineText.length;
+  if (startPos === -1) {return undefined;}
+  if (endPos === -1) {endPos = lineText.length;}
 
   // Skip the single pad space that formatTable inserts after the opening pipe.
-  if (lineText[startPos] === ' ') startPos++;
+  if (lineText[startPos] === ' ') {startPos++;}
 
   let trimmedEnd = endPos;
   while (trimmedEnd > startPos && /\s/.test(lineText[trimmedEnd - 1])) {

--- a/src/table/commands/rowColumn.ts
+++ b/src/table/commands/rowColumn.ts
@@ -12,7 +12,7 @@ async function transformTable(
   transform: (model: TableModel, coords: { rowIndex: number; columnIndex: number }) => TableModel | null
 ): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
 
   const document = editor.document;
   const cursorLine = editor.selection.active.line;
@@ -30,7 +30,7 @@ async function transformTable(
 
   const model = parseTable(document, location);
   const newModel = transform(model, coords);
-  if (!newModel) return;
+  if (!newModel) {return;}
 
   const formatted = formatTable(newModel);
   await editor.edit((edit) => {
@@ -96,7 +96,7 @@ export async function deleteRowCommand(): Promise<void> {
       vscode.window.showInformationMessage('Markdown Foundry: cannot delete the header row.');
       return null;
     }
-    if (model.rows.length === 0) return null;
+    if (model.rows.length === 0) {return null;}
     const rows = [...model.rows];
     rows.splice(rowIndex, 1);
     return { ...model, rows };
@@ -124,7 +124,7 @@ export async function deleteColumnCommand(): Promise<void> {
 
 export async function moveRowUpCommand(): Promise<void> {
   await transformTable((model, { rowIndex }) => {
-    if (rowIndex <= 0) return null;
+    if (rowIndex <= 0) {return null;}
     const rows = [...model.rows];
     [rows[rowIndex - 1], rows[rowIndex]] = [rows[rowIndex], rows[rowIndex - 1]];
     return { ...model, rows };
@@ -133,7 +133,7 @@ export async function moveRowUpCommand(): Promise<void> {
 
 export async function moveRowDownCommand(): Promise<void> {
   await transformTable((model, { rowIndex }) => {
-    if (rowIndex < 0 || rowIndex >= model.rows.length - 1) return null;
+    if (rowIndex < 0 || rowIndex >= model.rows.length - 1) {return null;}
     const rows = [...model.rows];
     [rows[rowIndex + 1], rows[rowIndex]] = [rows[rowIndex], rows[rowIndex + 1]];
     return { ...model, rows };
@@ -142,14 +142,14 @@ export async function moveRowDownCommand(): Promise<void> {
 
 export async function moveColumnLeftCommand(): Promise<void> {
   await transformTable((model, { columnIndex }) => {
-    if (columnIndex <= 0) return null;
+    if (columnIndex <= 0) {return null;}
     return swapColumns(model, columnIndex, columnIndex - 1);
   });
 }
 
 export async function moveColumnRightCommand(): Promise<void> {
   await transformTable((model, { columnIndex }) => {
-    if (columnIndex >= model.headers.length - 1) return null;
+    if (columnIndex >= model.headers.length - 1) {return null;}
     return swapColumns(model, columnIndex, columnIndex + 1);
   });
 }

--- a/src/table/commands/sort.ts
+++ b/src/table/commands/sort.ts
@@ -11,7 +11,7 @@ import { formatTable } from '../formatter';
  */
 export async function sortByColumnCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return;
+  if (!editor) {return;}
   const document = editor.document;
   const cursorLine = editor.selection.active.line;
   const location = locateTable(document, cursorLine);
@@ -21,7 +21,7 @@ export async function sortByColumnCommand(): Promise<void> {
   }
 
   const coords = cursorToTableCoords(document, location, editor.selection.active);
-  if (!coords) return;
+  if (!coords) {return;}
 
   const direction = await vscode.window.showQuickPick(
     [
@@ -30,14 +30,14 @@ export async function sortByColumnCommand(): Promise<void> {
     ],
     { placeHolder: `Sort direction for column ${coords.columnIndex + 1}` }
   );
-  if (!direction) return;
+  if (!direction) {return;}
 
   const model = parseTable(document, location);
   const col = coords.columnIndex;
 
   const isNumeric = model.rows.every((row) => {
     const value = (row[col] ?? '').trim();
-    if (value === '') return true;
+    if (value === '') {return true;}
     return !isNaN(Number(value));
   });
 

--- a/src/table/formatter.ts
+++ b/src/table/formatter.ts
@@ -67,7 +67,7 @@ function formatSeparator(alignments: Alignment[], widths: number[]): string {
 
 function padCell(cell: string, width: number, alignment: Alignment): string {
   const diff = width - visualWidth(cell);
-  if (diff <= 0) return cell;
+  if (diff <= 0) {return cell;}
 
   switch (alignment) {
     case 'right':

--- a/src/table/locator.ts
+++ b/src/table/locator.ts
@@ -149,8 +149,8 @@ function characterOffsetToColumnIndex(lineText: string, charOffset: number): num
   let column = 0;
   let i = 0;
   // Skip leading indent and the first |
-  while (i < lineText.length && lineText[i] !== '|') i++;
-  if (i < lineText.length) i++; // consume opening |
+  while (i < lineText.length && lineText[i] !== '|') {i++;}
+  if (i < lineText.length) {i++;} // consume opening |
 
   while (i < charOffset && i < lineText.length) {
     if (lineText[i] === '\\' && i + 1 < lineText.length && lineText[i + 1] === '|') {

--- a/src/table/parser.ts
+++ b/src/table/parser.ts
@@ -106,9 +106,9 @@ function cellToAlignment(cell: string): Alignment {
   const startsWithColon = trimmed.startsWith(':');
   const endsWithColon = trimmed.endsWith(':');
 
-  if (startsWithColon && endsWithColon) return 'center';
-  if (endsWithColon) return 'right';
-  if (startsWithColon) return 'left';
+  if (startsWithColon && endsWithColon) {return 'center';}
+  if (endsWithColon) {return 'right';}
+  if (startsWithColon) {return 'left';}
   return 'none';
 }
 
@@ -117,7 +117,7 @@ function cellToAlignment(cell: string): Alignment {
  * Pads with empty strings, truncates extras.
  */
 function normalizeRowWidth(row: string[], width: number): string[] {
-  if (row.length === width) return row;
+  if (row.length === width) {return row;}
   if (row.length < width) {
     return [...row, ...Array(width - row.length).fill('')];
   }

--- a/src/test/suite/pasteLink.test.ts
+++ b/src/test/suite/pasteLink.test.ts
@@ -60,11 +60,11 @@ suite('pasteLink: classifyClipboard', () => {
   });
 
   test('file:// URI on POSIX resolves to a path that exists', () => {
-    if (process.platform === 'win32') return;
+    if (process.platform === 'win32') {return;}
     const uri = 'file://' + txtFile;
     const r = classifyClipboard(uri, { platform: 'linux' });
     assert.strictEqual(r.kind, 'path');
-    if (r.kind === 'path') assert.strictEqual(r.absPath, txtFile);
+    if (r.kind === 'path') {assert.strictEqual(r.absPath, txtFile);}
   });
 
   test('file:// URI on Windows strips the leading slash before the drive letter', () => {
@@ -92,7 +92,7 @@ suite('pasteLink: classifyClipboard', () => {
         : 'file://' + target.replace(/ /g, '%20');
       const r = classifyClipboard(uri);
       assert.strictEqual(r.kind, 'path');
-      if (r.kind === 'path') assert.strictEqual(r.absPath, target);
+      if (r.kind === 'path') {assert.strictEqual(r.absPath, target);}
     } finally {
       fs.rmSync(target, { force: true });
     }

--- a/src/util/contextKey.ts
+++ b/src/util/contextKey.ts
@@ -34,8 +34,8 @@ export function registerInTableContext(context: vscode.ExtensionContext): void {
 }
 
 function isInTable(editor: vscode.TextEditor | undefined): boolean {
-  if (!editor) return false;
-  if (editor.document.languageId !== 'markdown') return false;
+  if (!editor) {return false;}
+  if (editor.document.languageId !== 'markdown') {return false;}
   const line = editor.selection.active.line;
   return locateTable(editor.document, line) !== null;
 }


### PR DESCRIPTION
## Summary

- Tightens `.eslintrc.json` to match Selection-Count and AL-EventLens — promotes `semi`/`curly`/`eqeqeq`/`no-throw-literal` to error, adds `@typescript-eslint/no-explicit-any` and `no-unused-vars` at error level.
- Auto-fixes the ~95 resulting `curly` violations across 18 source files. No behavior change — `eslint --fix` only adds braces around single-statement `if`/`while` bodies.

Validated locally: `npx eslint src --ext ts` exit 0, `npx tsc --noEmit` clean, `node esbuild.js --production` clean, `npm test` → 165 passing.

No CHANGELOG entry — contributor-facing only (config + mechanical refactor).
No README change.

Closes #101