### PR TITLE
Add contributor scaffolding: issue forms, PR template, CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Something in Markdown Foundry isn't working as documented
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the bug — what you did and what went wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open a Markdown file containing ...
+        2. Place the cursor in ...
+        3. Run the command "Markdown Foundry: ..."
+        4. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: sample
+    attributes:
+      label: Sample Markdown
+      description: If the bug involves a specific table or document, paste the smallest Markdown snippet that reproduces it.
+      render: markdown
+    validations:
+      required: false
+  - type: input
+    id: extension-version
+    attributes:
+      label: Extension version
+      placeholder: e.g. 0.5.0
+    validations:
+      required: true
+  - type: input
+    id: vscode-version
+    attributes:
+      label: VS Code version
+      placeholder: e.g. 1.90.0 (Help → About)
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux (X11)
+        - Linux (Wayland)
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else that might help — other Markdown extensions installed, relevant `markdownFoundry.*` settings, screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new command, setting, or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: What should change or be added? Be concrete — e.g. a new command, a new setting, a behavior change to an existing command.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: The motivation and any relevant context. What problem does this solve in your Markdown workflow?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: A checklist of observable outcomes that would make this issue "done". Detailed criteria let the issue be worked independently.
+      placeholder: |
+        - [ ] Running "Markdown Foundry: ..." does ...
+        - [ ] With no selection, ...
+        - [ ] Existing behavior X is unchanged
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or existing commands/extensions you tried, and why they don't fit.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- 1-3 bullets: what this PR changes and why. -->
+
+-
+
+## Checklist
+
+<!-- CI (.github/workflows/build.yml) runs the type check, production bundle, tests, and a vsce package smoke test on Linux/macOS/Windows. Run the same checks locally before pushing: -->
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `node esbuild.js --production` succeeds
+- [ ] `npm test` passes (required if you touched `src/table/` or `src/insert/`; CI runs it on every PR)
+- [ ] New/changed logic in `src/table/parser.ts`, `formatter.ts`, `locator.ts`, or `src/insert/` has unit tests in `src/test/suite/`
+- [ ] `CHANGELOG.md` `[Unreleased]` updated if this is a user-visible change (new/changed commands, settings, keybindings, user-facing fixes) — not needed for refactors, tests, CI, or contributor docs
+- [ ] `README.md` updated if this adds/removes/changes a user-discoverable command, setting, or keybinding
+- [ ] One PR per issue; no unrelated changes bundled
+
+Closes #<!-- issue number -->

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,6 +14,7 @@ vsc-extension-quickstart.md
 node_modules/**
 .github/**
 CLAUDE.md
+CONTRIBUTING.md
 CONTEXT.md
 GETTING_STARTED.md
 agents/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to Markdown Foundry
+
+Thanks for your interest in contributing! This document covers setup, the build/test commands, and how changes flow from issue to merged PR in this repository.
+
+## Prerequisites
+
+- Node.js 20.x (what CI uses)
+- Visual Studio Code 1.85 or later
+
+## Setup
+
+```sh
+git clone https://github.com/dvlprlife/Markdown-Foundry.git
+cd Markdown-Foundry
+npm ci
+```
+
+## Build, lint, test
+
+| Command | What it does |
+| --- | --- |
+| `npm run check-types` | Type check (`tsc --noEmit`) |
+| `npm run compile` | Type check + compile to `dist/` + esbuild bundle |
+| `npm run watch` | Watch mode (esbuild + tsc in parallel) |
+| `npm run lint` | ESLint over `src/` |
+| `npm test` | Runs the test suite via `vscode-test` (downloads a VS Code build on first run). `pretest` compiles and lints first. |
+| `node esbuild.js --production` | Production bundle (what CI and packaging use) |
+
+Before committing, all of these must pass (see [CLAUDE.md](CLAUDE.md)):
+
+```sh
+npx tsc --noEmit
+node esbuild.js --production
+npm test            # required if you touched src/table/ or src/insert/
+```
+
+## Running the extension
+
+Open the repo in VS Code and press `F5` (the **Run Extension** launch configuration). It compiles automatically and opens an Extension Development Host with the extension loaded. The **Extension Tests** launch configuration runs the test suite under the debugger.
+
+## Issue → PR workflow
+
+Every change starts with a GitHub issue:
+
+1. **Open an issue first** using the issue forms. The body should say **what** is changing, **why**, and include **acceptance criteria** as a checklist — detailed enough that someone else could work it independently.
+2. **Branch off `main`**, named `issue-{number}-short-description` (kebab-case, 2-4 words), e.g. `issue-12-paste-image-windows`.
+3. **Commit** with a brief imperative subject line and `Closes #{number}` in the commit body.
+4. **Open a PR** whose body starts with `## Summary` (1-3 bullets) and ends with `Closes #{number}`.
+
+Hard rules:
+
+- Never push directly to `main` — all changes land via pull request.
+- One PR per issue; don't bundle unrelated work.
+
+Note: this repo also has an automated agent pipeline (see [`agents/WORKFLOW.md`](agents/WORKFLOW.md)) that processes issues labeled `agent` + `status: *`. Those labels are applied by maintainers — as a contributor you don't need to set them, and please don't modify files under `agents/` in a feature PR.
+
+## What CI checks
+
+`.github/workflows/build.yml` runs on every PR and push to `main`, on Linux, macOS, and Windows:
+
+- `npm ci`
+- `npx tsc --noEmit`
+- `node esbuild.js --production`
+- `npm test` (under `xvfb-run` on Linux)
+- `npx @vscode/vsce package` smoke test (Linux only)
+
+## Tests
+
+- Any change to `src/table/parser.ts`, `src/table/formatter.ts`, `src/table/locator.ts`, or `src/insert/` requires a unit test in `src/test/suite/`.
+- New table commands should have at least one integration-style test exercising the full parse → transform → format pipeline.
+- Don't delete failing tests to make CI pass — fix the code or the test.
+
+## CHANGELOG and README
+
+- **User-visible changes** (new/changed commands, settings, keybindings, user-facing bug fixes) need an entry under `## [Unreleased]` in `CHANGELOG.md` ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format). Refactors, test-only changes, CI, and contributor docs don't.
+- **User-discoverable changes** (commands, settings, keybindings added/removed/changed) must update `README.md` in the same PR — it is the Marketplace listing and always describes current `main`.
+
+## Code conventions
+
+[CLAUDE.md](CLAUDE.md) is the authoritative rules file (the PR reviewer enforces it). Highlights:
+
+- Strict TypeScript: no `any`, no unused locals/params, explicit returns. Don't suppress with `// @ts-ignore` or `// eslint-disable`.
+- **Locate, don't parse**: table commands operate on the table at the cursor via `locator.ts` → `parser.ts` → `formatter.ts`, replacing only that range.
+- **Layer discipline**: `locator`/`parser`/`formatter` are pure; only `src/table/commands/` and `src/insert/` touch the editor.
+- Use forward slashes in Markdown paths inserted into documents.
+- Comments only for non-obvious *why*, never *what*; no issue/PR references in code comments.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ All other commands are available through the Command Palette (search for "Markdo
 
 Please file issues and feature requests on [GitHub](https://github.com/dvlprlife/Markdown-Foundry).
 
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](https://github.com/dvlprlife/Markdown-Foundry/blob/main/CONTRIBUTING.md) for setup, build/test commands, and the issue → PR workflow.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Add GitHub issue forms (`bug_report.yml`, `feature_request.yml`) that apply the existing `bug`/`enhancement` labels; the feature form mirrors the What / Why / Acceptance-criteria issue-body convention from CLAUDE.md. `config.yml` disables blank issues.
- Add `.github/pull_request_template.md` whose checklist mirrors the actual CI checks in `build.yml` (`tsc --noEmit`, `esbuild --production`, `npm test`) plus the CHANGELOG/README rules CLAUDE.md's PR reviewer enforces.
- Add `CONTRIBUTING.md` covering setup (`npm ci`, Node 20), the real `package.json` scripts, F5 / `vscode-test` extension runs, the issue → PR workflow (`issue-{number}-…` branches, `## Summary` + `Closes #N` PR bodies), what CI runs, and pointers to CLAUDE.md and `agents/WORKFLOW.md`; README gains a 2-line `## Contributing` pointer, and CONTRIBUTING.md is excluded from the vsix via `.vscodeignore` (consistent with CLAUDE.md).

No CHANGELOG entry — contributor-facing docs and CI/`.vscodeignore` updates are explicitly exempt per CLAUDE.md.

Note: this PR has no associated issue and uses a `chore/` branch name by explicit maintainer instruction for this one-off scaffolding task (the repo's `issue-{number}-…` convention presumes an existing issue).

Verification: all three YAML files parse cleanly with js-yaml; `npm run check-types` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
