### PR TITLE
Sort by Column: message on separator row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Fixed
+
+- `Sort Table by Column` now shows an explanatory message when invoked with the cursor on the separator row, instead of doing nothing silently ([#104](https://github.com/dvlprlife/Markdown-Foundry/pull/104)).
+
 ## [0.5.0] - 2026-05-09
 
 ### Added

--- a/src/table/commands/sort.ts
+++ b/src/table/commands/sort.ts
@@ -21,7 +21,10 @@ export async function sortByColumnCommand(): Promise<void> {
   }
 
   const coords = cursorToTableCoords(document, location, editor.selection.active);
-  if (!coords) {return;}
+  if (!coords) {
+    vscode.window.showInformationMessage('Markdown Foundry: cursor is on the separator row.');
+    return;
+  }
 
   const direction = await vscode.window.showQuickPick(
     [


### PR DESCRIPTION
## Summary

- `Sort Table by Column` showed no feedback when invoked with the cursor on the separator row; now it shows the same info message the other table commands use.

## Testing

- `npx tsc --noEmit` clean
- `node esbuild.js --production` clean
- `npm test` → 165 passing

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)