### PR TITLE
Tab: don't hijack inline-suggestion accept in tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Fixed
+
+- Table-cell `Tab` navigation no longer overrides accepting an inline suggestion (e.g. Copilot ghost text) — the keybinding now also requires `!inlineSuggestionVisible` ([#105](https://github.com/dvlprlife/Markdown-Foundry/pull/105)).
+
 ## [0.5.0] - 2026-05-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ These are non-negotiable:
 - **Layer discipline.** `locator` / `parser` / `formatter` are pure (no `vscode` imports beyond types). Only files in `src/table/commands/` and `src/insert/` touch the editor.
 - **Forward slashes in inserted Markdown.** When writing a path into the document, normalize with `path.relative(...).split(path.sep).join('/')`. Markdown rendered on non-Windows must work.
 - **Stubs fail loudly.** A not-yet-implemented platform handler must throw with a clear message (e.g. `"saveClipboardImage: Linux/Wayland not yet supported"`), never silently no-op or return a fake success.
-- **Tab/Shift-Tab/Enter gating.** Keybindings must include `markdownFoundry.inTable && !suggestWidgetVisible` so default editor behavior is preserved outside tables and the suggest widget is not hijacked. The nav commands intentionally fire with a live selection so Tab-after-cell-select advances to the next cell instead of replacing the selection with a literal tab character.
+- **Tab/Shift-Tab/Enter gating.** Keybindings must include `markdownFoundry.inTable && !suggestWidgetVisible` so default editor behavior is preserved outside tables and the suggest widget is not hijacked. The `tab` binding must additionally include `!inlineSuggestionVisible` so inline-suggestion (ghost text) accept is never overridden. The nav commands intentionally fire with a live selection so Tab-after-cell-select advances to the next cell instead of replacing the selection with a literal tab character.
 
 ## Tests
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
       {
         "command": "markdownFoundry.nextCell",
         "key": "tab",
-        "when": "editorTextFocus && editorLangId == markdown && markdownFoundry.inTable && !suggestWidgetVisible"
+        "when": "editorTextFocus && editorLangId == markdown && markdownFoundry.inTable && !suggestWidgetVisible && !inlineSuggestionVisible"
       },
       {
         "command": "markdownFoundry.previousCell",


### PR DESCRIPTION
## Summary

- The in-table `Tab` → Next Cell keybinding gated on `!suggestWidgetVisible` but not `!inlineSuggestionVisible`, so Tab overrode accepting inline-suggestion (Copilot-style) ghost text. Added `!inlineSuggestionVisible` to the `when` clause; `shift+tab` / `enter` unchanged.
- Updated the CLAUDE.md Tab/Shift-Tab/Enter gating rule to document the new context key.

## Testing

- `package.json` parses; `npx tsc --noEmit` and `node esbuild.js --production` clean.
- No runtime code change (manifest + docs only), so the test suite is unaffected.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)