### PR TITLE
Tab-select excludes alignment padding in aligned cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Fixed
+
+- Tab-selecting a cell in a right- or center-aligned column now selects only the cell's content, not the surrounding alignment padding — so typing over the selection no longer eats the padding and misaligns the table ([#106](https://github.com/dvlprlife/Markdown-Foundry/pull/106)).
+
 ## [0.5.0] - 2026-05-09
 
 ### Added

--- a/src/table/commands/navigate.ts
+++ b/src/table/commands/navigate.ts
@@ -159,13 +159,24 @@ export function computeCellRange(
   if (startPos === -1) {return undefined;}
   if (endPos === -1) {endPos = lineText.length;}
 
-  // Skip the single pad space that formatTable inserts after the opening pipe.
-  if (lineText[startPos] === ' ') {startPos++;}
+  // Skip all leading whitespace so right/center-aligned cells select their
+  // content only, not the alignment padding formatTable inserts.
+  let contentStart = startPos;
+  while (contentStart < endPos && /\s/.test(lineText[contentStart])) {
+    contentStart++;
+  }
+
+  // Whitespace-only cell: collapse to a cursor one space after the opening
+  // pipe (the position formatTable pads to), matching prior behavior.
+  if (contentStart === endPos) {
+    const caret = lineText[startPos] === ' ' ? startPos + 1 : startPos;
+    return { start: caret, end: caret };
+  }
 
   let trimmedEnd = endPos;
-  while (trimmedEnd > startPos && /\s/.test(lineText[trimmedEnd - 1])) {
+  while (trimmedEnd > contentStart && /\s/.test(lineText[trimmedEnd - 1])) {
     trimmedEnd--;
   }
 
-  return { start: startPos, end: trimmedEnd };
+  return { start: contentStart, end: trimmedEnd };
 }

--- a/src/test/suite/navigate.test.ts
+++ b/src/test/suite/navigate.test.ts
@@ -36,4 +36,25 @@ suite('navigate: computeCellRange', () => {
     const result = computeCellRange(line, 5);
     assert.strictEqual(result, undefined);
   });
+
+  test('excludes leading padding in a right-aligned cell', () => {
+    const line = '|   42 | x |';
+    const result = computeCellRange(line, 0);
+    // "42" sits at chars 4-6; the leading pad spaces are not selected.
+    assert.deepStrictEqual(result, { start: 4, end: 6 });
+  });
+
+  test('excludes surrounding padding in a center-aligned cell', () => {
+    const line = '|  mid  | x |';
+    const result = computeCellRange(line, 0);
+    // "mid" sits at chars 3-6, padding on both sides excluded.
+    assert.deepStrictEqual(result, { start: 3, end: 6 });
+  });
+
+  test('escaped-pipe cell with leading padding still selects content only', () => {
+    const line = '|   a \\| b | x |';
+    const result = computeCellRange(line, 0);
+    // Content "a \| b" starts after the padding; escape stays inside the cell.
+    assert.deepStrictEqual(result, { start: 4, end: 10 });
+  });
 });


### PR DESCRIPTION
## Summary

- In right- or center-aligned columns, Tab-selecting a cell included the leading alignment padding, so typing over the selection destroyed the padding and misaligned the table. `computeCellRange` now skips all leading whitespace.
- Whitespace-only cells still collapse to a cursor one space after the opening pipe (unchanged).

## Testing

- Added three tests (right-aligned, center-aligned, escaped-pipe-with-padding) to `navigate.test.ts`.
- `npx tsc --noEmit` clean, `node esbuild.js --production` clean, `npm test` → 168 passing (was 165).

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)