### PR TITLE
Paste Image: don't overwrite on filename collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Fixed
+
+- `Paste Image` no longer silently overwrites an existing image when the generated filename collides (e.g. two pastes within the same second) — it now appends `-1`, `-2`, … until the name is free ([#108](https://github.com/dvlprlife/Markdown-Foundry/pull/108)).
+
 ## [0.5.0] - 2026-05-09
 
 ### Added

--- a/src/insert/image.ts
+++ b/src/insert/image.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { createWriteStream, promises as fs } from 'fs';
+import { createWriteStream, existsSync, promises as fs } from 'fs';
 import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 
@@ -26,8 +26,8 @@ export async function pasteImageCommand(): Promise<void> {
   const imageDir = path.join(docDir, folderName);
   await fs.mkdir(imageDir, { recursive: true });
 
-  const filename = expandNameFormat(nameFormat, document.uri.fsPath) + '.png';
-  const targetPath = path.join(imageDir, filename);
+  const baseName = expandNameFormat(nameFormat, document.uri.fsPath);
+  const targetPath = uniqueTargetPath(imageDir, baseName, '.png');
 
   try {
     await saveClipboardImage(targetPath);
@@ -41,6 +41,26 @@ export async function pasteImageCommand(): Promise<void> {
   const relative = path.relative(docDir, targetPath).split(path.sep).join('/');
   const markdown = `![](${relative})`;
   await editor.edit((edit) => edit.insert(editor.selection.active, markdown));
+}
+
+/**
+ * Return a path under `dir` for `baseName + ext` that does not already exist.
+ * If the plain name is taken, appends `-1`, `-2`, … before the extension until
+ * a free name is found, so a paste never silently overwrites an earlier image.
+ */
+export function uniqueTargetPath(
+  dir: string,
+  baseName: string,
+  ext: string,
+  exists: (p: string) => boolean = existsSync
+): string {
+  let candidate = path.join(dir, baseName + ext);
+  let n = 1;
+  while (exists(candidate)) {
+    candidate = path.join(dir, `${baseName}-${n}${ext}`);
+    n++;
+  }
+  return candidate;
 }
 
 function expandNameFormat(template: string, documentPath: string): string {

--- a/src/test/suite/pasteImage.test.ts
+++ b/src/test/suite/pasteImage.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { uniqueTargetPath } from '../../insert/image';
+
+suite('image: uniqueTargetPath', () => {
+  const dir = path.join('some', 'images');
+
+  test('returns the plain name when nothing exists', () => {
+    const result = uniqueTargetPath(dir, 'image-x', '.png', () => false);
+    assert.strictEqual(result, path.join(dir, 'image-x.png'));
+  });
+
+  test('suffixes -1 when the plain name is taken', () => {
+    const taken = new Set([path.join(dir, 'image-x.png')]);
+    const result = uniqueTargetPath(dir, 'image-x', '.png', (p) => taken.has(p));
+    assert.strictEqual(result, path.join(dir, 'image-x-1.png'));
+  });
+
+  test('finds the first free suffix after several collisions', () => {
+    const taken = new Set([
+      path.join(dir, 'image-x.png'),
+      path.join(dir, 'image-x-1.png'),
+      path.join(dir, 'image-x-2.png')
+    ]);
+    const result = uniqueTargetPath(dir, 'image-x', '.png', (p) => taken.has(p));
+    assert.strictEqual(result, path.join(dir, 'image-x-3.png'));
+  });
+});


### PR DESCRIPTION
## Summary

- `Paste Image` built `image-${timestamp}.png` (one-second granularity) and saved without checking for an existing file, so two pastes within the same second silently overwrote the first image while leaving two Markdown references to it.
- Added `uniqueTargetPath(dir, baseName, ext, exists?)`, which appends `-1`, `-2`, … until the name is free; the command uses the returned path for both the clipboard save and the inserted Markdown, so the reference always matches the file written.

## Testing

- Unit tests for `uniqueTargetPath` (no collision, single collision, several consecutive collisions) with an injected existence check.
- `npx tsc --noEmit`, `npx eslint src --ext ts`, `node esbuild.js --production` clean.
- `npm test` → 168 passing (was 165).

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)