### PR TITLE
Escape link destinations containing spaces or parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Fixed
+
+- `Insert Link to File`, `Paste Link`, and `Paste Image` now wrap link destinations containing spaces or parentheses in angle brackets (`[text](<my file.docx>)`), so links to such paths render correctly instead of producing broken Markdown ([#109](https://github.com/dvlprlife/Markdown-Foundry/pull/109)).
+
 ## [0.5.0] - 2026-05-09
 
 ### Added

--- a/src/insert/image.ts
+++ b/src/insert/image.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { createWriteStream, promises as fs } from 'fs';
 import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
+import { formatLinkDestination } from './markdownLink';
 
 const execFileAsync = promisify(execFile);
 
@@ -39,7 +40,7 @@ export async function pasteImageCommand(): Promise<void> {
   }
 
   const relative = path.relative(docDir, targetPath).split(path.sep).join('/');
-  const markdown = `![](${relative})`;
+  const markdown = `![](${formatLinkDestination(relative)})`;
   await editor.edit((edit) => edit.insert(editor.selection.active, markdown));
 }
 

--- a/src/insert/link.ts
+++ b/src/insert/link.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { URL as NodeURL } from 'url';
 import { isImageExtension } from './imageExtensions';
+import { formatLinkDestination } from './markdownLink';
 
 export type ClipboardKind =
   | { kind: 'url'; value: string }
@@ -81,7 +82,7 @@ export async function pasteLinkCommand(): Promise<void> {
       'Link text (leave empty to use the URL)'
     );
     if (text === undefined) {return;}
-    await applyEdit(editor, selection, `[${text}](${url})`);
+    await applyEdit(editor, selection, `[${text}](${formatLinkDestination(url)})`);
     return;
   }
 
@@ -103,7 +104,8 @@ export async function pasteLinkCommand(): Promise<void> {
   );
   if (text === undefined) {return;}
 
-  const markdown = result.isImage ? `![${text}](${rel})` : `[${text}](${rel})`;
+  const dest = formatLinkDestination(rel);
+  const markdown = result.isImage ? `![${text}](${dest})` : `[${text}](${dest})`;
   await applyEdit(editor, selection, markdown);
 }
 

--- a/src/insert/linkToFile.ts
+++ b/src/insert/linkToFile.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { isImageExtension } from './imageExtensions';
+import { formatLinkDestination } from './markdownLink';
 
 const MAX_RESULTS = 5000;
 
@@ -38,7 +39,8 @@ export function sortFileItems<T extends SortableItem>(items: T[], currentDir: st
 }
 
 export function formatInsertion(text: string, relPath: string, isImage: boolean): string {
-  return isImage ? `![${text}](${relPath})` : `[${text}](${relPath})`;
+  const dest = formatLinkDestination(relPath);
+  return isImage ? `![${text}](${dest})` : `[${text}](${dest})`;
 }
 
 interface FileQuickPickItem extends vscode.QuickPickItem {

--- a/src/insert/markdownLink.ts
+++ b/src/insert/markdownLink.ts
@@ -1,0 +1,12 @@
+/**
+ * Format a link/image destination for embedding in a Markdown `(...)` target.
+ *
+ * A destination containing whitespace or parentheses is not a valid CommonMark
+ * inline-link target on its own, so it is wrapped in angle brackets (the
+ * `<...>` destination form). Any literal `<` or `>` inside is backslash-escaped
+ * so the wrapper stays balanced. Clean destinations are returned unchanged.
+ */
+export function formatLinkDestination(dest: string): string {
+  if (!/[\s()]/.test(dest)) {return dest;}
+  return '<' + dest.replace(/([<>])/g, '\\$1') + '>';
+}

--- a/src/test/suite/linkToFile.test.ts
+++ b/src/test/suite/linkToFile.test.ts
@@ -110,4 +110,11 @@ suite('linkToFile: formatInsertion', () => {
   test('image renders as ![text](rel)', () => {
     assert.strictEqual(formatInsertion('hero', 'images/hero.png', true), '![hero](images/hero.png)');
   });
+
+  test('wraps a destination containing spaces in angle brackets', () => {
+    assert.strictEqual(
+      formatInsertion('report', 'My Docs/report.pdf', false),
+      '[report](<My Docs/report.pdf>)'
+    );
+  });
 });

--- a/src/test/suite/markdownLink.test.ts
+++ b/src/test/suite/markdownLink.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import { formatLinkDestination } from '../../insert/markdownLink';
+
+suite('markdownLink: formatLinkDestination', () => {
+  test('leaves a clean path unchanged', () => {
+    assert.strictEqual(formatLinkDestination('images/hero.png'), 'images/hero.png');
+  });
+
+  test('wraps a path containing spaces', () => {
+    assert.strictEqual(
+      formatLinkDestination('My Documents/file.docx'),
+      '<My Documents/file.docx>'
+    );
+  });
+
+  test('wraps a path containing parentheses', () => {
+    assert.strictEqual(formatLinkDestination('images/file (1).png'), '<images/file (1).png>');
+  });
+
+  test('escapes literal angle brackets inside a wrapped destination', () => {
+    assert.strictEqual(formatLinkDestination('a <b> c'), '<a \\<b\\> c>');
+  });
+
+  test('leaves a clean URL unchanged', () => {
+    assert.strictEqual(
+      formatLinkDestination('https://example.com/foo'),
+      'https://example.com/foo'
+    );
+  });
+
+  test('wraps a URL containing parentheses', () => {
+    assert.strictEqual(
+      formatLinkDestination('https://en.wikipedia.org/wiki/Foo_(bar)'),
+      '<https://en.wikipedia.org/wiki/Foo_(bar)>'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `Insert Link to File`, `Paste Link`, and `Paste Image` emitted link destinations raw, so a path with spaces or parentheses (routine on Windows, e.g. `file (1).png`) produced invalid CommonMark that rendered broken.
- Added `src/insert/markdownLink.ts` → `formatLinkDestination`, which wraps destinations containing whitespace or parens in the CommonMark angle-bracket form (`<...>`, escaping any literal `<`/`>`) and returns clean destinations unchanged. Routed all three insertion paths (including both the URL and file-path branches of Paste Link) through it.

## Testing

- New `markdownLink.test.ts` (clean path, spaces, parens, angle-bracket escaping, clean URL, URL with parens) plus an added spaced-path case in `linkToFile.test.ts`.
- `npx tsc --noEmit`, `npx eslint src --ext ts`, `node esbuild.js --production` clean.
- `npm test` → 172 passing (was 165).
- Note: output conforms to the CommonMark angle-bracket destination form (what VS Code's markdown-it preview renders as a link) and the exact strings are unit-tested; a headless preview render was not performed (no Markdown renderer in the toolchain).

## Merge order

Touches `src/insert/image.ts` in a different region than #108; land after #108. The changes are non-overlapping and auto-merge cleanly.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)