### PR TITLE
Clean dist/ on compile so stale test files don't run

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
-    "compile": "npm run check-types && tsc --outDir dist && node esbuild.js",
+    "compile": "npm run clean && npm run check-types && tsc --outDir dist && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",


### PR DESCRIPTION
## Summary
- `compile` now runs `npm run clean` first, so `dist/` is emptied before `tsc --outDir dist` emits — stale compiled `.test.js` files from deleted/renamed sources can no longer be picked up by the test runner's `dist/test/**/*.test.js` glob
- `watch:*` scripts don't call `compile` and `package` already cleans independently, so both are unchanged

No CHANGELOG or README entry: contributor-facing build tooling only, no user-visible change.

Verified by planting a fake stale `dist/test/suite/stalefake.test.js` and running `npm test` — the file was removed by the clean, the fake suite never ran, and the run showed 201 passing (exit 0). `npx tsc --noEmit` and `node esbuild.js --production` both clean.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)