### PR TITLE
Toggle Task List Item mangles * and + bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 - Tab-selecting a cell in a right- or center-aligned column now selects only the cell's content, not the surrounding alignment padding — so typing over the selection no longer eats the padding and misaligns the table ([#106](https://github.com/dvlprlife/Markdown-Foundry/pull/106)).
 - `Paste Image` no longer silently overwrites an existing image when the generated filename collides (e.g. two pastes within the same second) — it now appends `-1`, `-2`, … until the name is free ([#108](https://github.com/dvlprlife/Markdown-Foundry/pull/108)).
 - `Insert Link to File`, `Paste Link`, and `Paste Image` now wrap link destinations containing spaces or parentheses in angle brackets (`[text](<my file.docx>)`), so links to such paths render correctly instead of producing broken Markdown ([#109](https://github.com/dvlprlife/Markdown-Foundry/pull/109)).
+- `Toggle Task List Item` now recognizes `*` and `+` bullets, cycling them in place (`* item` → `* [ ] item` → `* [x] item`) instead of mangling them into `- [ ] * item` ([#126](https://github.com/dvlprlife/Markdown-Foundry/pull/126)).
 
 ## [0.5.0] - 2026-05-09
 

--- a/src/format/toggle.ts
+++ b/src/format/toggle.ts
@@ -128,8 +128,8 @@ export function toggleNumberedItem(text: string): string {
 /**
  * Cycle each non-empty line through: plain → `- [ ] x` → `- [x] x` → `- [ ] x`
  * → ... . Preserves leading indentation. A bullet line without a checkbox
- * (`- x`) is promoted to an unchecked task (`- [ ] x`). Empty lines pass
- * through unchanged.
+ * (`- x`, `* x`, or `+ x`) is promoted to an unchecked task keeping its
+ * bullet marker. Empty lines pass through unchanged.
  */
 export function toggleTaskItem(text: string): string {
   return text.split(/\r?\n/).map(toggleTaskLine).join('\n');
@@ -142,13 +142,14 @@ function toggleTaskLine(line: string): string {
   const indent = indentMatch ? indentMatch[1] : '';
   const body = indentMatch ? indentMatch[2] : line;
 
-  const checked = body.match(/^-\s+\[x\]\s+(.*)$/i);
-  if (checked) {return `${indent}- [ ] ${checked[1]}`;}
+  const checked = body.match(/^([-*+])\s+\[x\]\s+(.*)$/i);
+  if (checked) {return `${indent}${checked[1]} [ ] ${checked[2]}`;}
 
-  const unchecked = body.match(/^-\s+\[ \]\s+(.*)$/);
-  if (unchecked) {return `${indent}- [x] ${unchecked[1]}`;}
+  const unchecked = body.match(/^([-*+])\s+\[ \]\s+(.*)$/);
+  if (unchecked) {return `${indent}${unchecked[1]} [x] ${unchecked[2]}`;}
 
-  const bullet = body.match(/^-\s+(.*)$/);
-  const bodyText = bullet ? bullet[1] : body;
-  return `${indent}- [ ] ${bodyText}`;
+  const bullet = body.match(/^([-*+])\s+(.*)$/);
+  if (bullet) {return `${indent}${bullet[1]} [ ] ${bullet[2]}`;}
+
+  return `${indent}- [ ] ${body}`;
 }

--- a/src/test/suite/toggle.test.ts
+++ b/src/test/suite/toggle.test.ts
@@ -210,6 +210,24 @@ suite('format: toggleTaskItem', () => {
       '- [ ] first\n\n- [ ] third'
     );
   });
+
+  test('asterisk bullet cycles keeping its marker', () => {
+    assert.strictEqual(toggleTaskItem('* item'), '* [ ] item');
+    assert.strictEqual(toggleTaskItem('* [ ] item'), '* [x] item');
+    assert.strictEqual(toggleTaskItem('* [x] item'), '* [ ] item');
+  });
+
+  test('plus bullet is promoted to an unchecked task keeping its marker', () => {
+    assert.strictEqual(toggleTaskItem('+ item'), '+ [ ] item');
+    assert.strictEqual(toggleTaskItem('+ [ ] item'), '+ [x] item');
+    assert.strictEqual(toggleTaskItem('+ [x] item'), '+ [ ] item');
+  });
+
+  test('indented asterisk bullet preserves indentation and marker', () => {
+    assert.strictEqual(toggleTaskItem('  * item'), '  * [ ] item');
+    assert.strictEqual(toggleTaskItem('  * [ ] item'), '  * [x] item');
+    assert.strictEqual(toggleTaskItem('  * [x] item'), '  * [ ] item');
+  });
 });
 
 suite('format: toggleBulletItem', () => {


### PR DESCRIPTION
## Summary
- `toggleTaskLine` (`src/format/toggle.ts`) now captures the bullet marker (`-`, `*`, or `+`) in its checked/unchecked/bullet patterns and preserves it when cycling, so `* item` cycles `* [ ] item` → `* [x] item` instead of becoming `- [ ] * item`.
- Added toggle.test.ts cases: full cycle for `*` and `+` bullets, indented `*` bullet preserving indentation and marker; existing `-` and plain-line tests cover the regression path.
- CHANGELOG `### Fixed` entry under `[Unreleased]`.

No README update: bug fix to an existing command; no new command, setting, or keybinding.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)