### PR TITLE
Heading toggles double-hash indented headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 - Tab-selecting a cell in a right- or center-aligned column now selects only the cell's content, not the surrounding alignment padding — so typing over the selection no longer eats the padding and misaligns the table ([#106](https://github.com/dvlprlife/Markdown-Foundry/pull/106)).
 - `Paste Image` no longer silently overwrites an existing image when the generated filename collides (e.g. two pastes within the same second) — it now appends `-1`, `-2`, … until the name is free ([#108](https://github.com/dvlprlife/Markdown-Foundry/pull/108)).
 - `Insert Link to File`, `Paste Link`, and `Paste Image` now wrap link destinations containing spaces or parentheses in angle brackets (`[text](<my file.docx>)`), so links to such paths render correctly instead of producing broken Markdown ([#109](https://github.com/dvlprlife/Markdown-Foundry/pull/109)).
+- Heading toggle and promote/demote now recognize headings indented by 1–3 spaces (valid CommonMark) — toggling `  ## Title` removes or swaps the heading instead of producing `## ## Title`, and promote/demote no longer silently no-op on indented headings. Lines indented 4+ spaces are still treated as code, not headings.
 
 ## [0.5.0] - 2026-05-09
 

--- a/src/format/toggle.ts
+++ b/src/format/toggle.ts
@@ -52,10 +52,12 @@ export function wrapLinePrefix(text: string, prefix: string): string {
 /**
  * Set the heading level of a line. `level === 0` removes the heading. If the
  * line is already at the target level, also removes the heading (toggle off).
- * Strips leading whitespace from the body when adding a heading.
+ * Strips leading whitespace from the body when adding a heading. Headings
+ * indented up to three spaces are recognized (CommonMark); four or more is
+ * an indented code block and is treated as body text.
  */
 export function wrapHeading(line: string, level: number): string {
-  const existing = line.match(/^(#{1,6})\s+(.*)$/);
+  const existing = line.match(/^ {0,3}(#{1,6})\s+(.*)$/);
   const body = existing ? existing[2] : line.replace(/^\s+/, '');
   const existingLevel = existing ? existing[1].length : 0;
 
@@ -68,10 +70,11 @@ export function wrapHeading(line: string, level: number): string {
 /**
  * Adjust an existing heading by `delta` (negative = promote toward H1,
  * positive = demote toward H6). No-op on non-heading lines or if the
- * adjustment would push the level outside [1, 6].
+ * adjustment would push the level outside [1, 6]. Headings indented up to
+ * three spaces are recognized (CommonMark) and re-emitted without the indent.
  */
 export function adjustHeading(line: string, delta: number): string {
-  const m = line.match(/^(#{1,6})\s+(.*)$/);
+  const m = line.match(/^ {0,3}(#{1,6})\s+(.*)$/);
   if (!m) {return line;}
   const newLevel = m[1].length + delta;
   if (newLevel < 1 || newLevel > 6) {return line;}

--- a/src/test/suite/toggle.test.ts
+++ b/src/test/suite/toggle.test.ts
@@ -128,6 +128,22 @@ suite('format: wrapHeading', () => {
     assert.strictEqual(wrapHeading('### Demoted', 0), 'Demoted');
   });
 
+  test('toggles off an indented heading at the same level', () => {
+    assert.strictEqual(wrapHeading('  ## Title', 2), 'Title');
+  });
+
+  test('changes level of an indented heading without double-hashing', () => {
+    assert.strictEqual(wrapHeading('  ## Title', 3), '### Title');
+  });
+
+  test('three-space-indented heading is still recognized', () => {
+    assert.strictEqual(wrapHeading('   ## Title', 2), 'Title');
+  });
+
+  test('four-space-indented hash line is body text, not a heading', () => {
+    assert.strictEqual(wrapHeading('    # code', 2), '## # code');
+  });
+
   test('level 0 on a non-heading line is effectively a leading-trim', () => {
     assert.strictEqual(wrapHeading('plain', 0), 'plain');
   });
@@ -157,6 +173,19 @@ suite('format: adjustHeading', () => {
   test('non-heading line is no-op', () => {
     assert.strictEqual(adjustHeading('plain text', -1), 'plain text');
     assert.strictEqual(adjustHeading('plain text', 1), 'plain text');
+  });
+
+  test('promotes an indented heading and drops the indent', () => {
+    assert.strictEqual(adjustHeading('   ## Title', -1), '# Title');
+  });
+
+  test('demotes an indented heading and drops the indent', () => {
+    assert.strictEqual(adjustHeading('   ## Title', 1), '### Title');
+  });
+
+  test('four-space-indented hash line is no-op (indented code block)', () => {
+    assert.strictEqual(adjustHeading('    # code', 1), '    # code');
+    assert.strictEqual(adjustHeading('    # code', -1), '    # code');
   });
 
   test('empty input is no-op', () => {


### PR DESCRIPTION
## Summary
- `wrapHeading` and `adjustHeading` (`src/format/toggle.ts`) now recognize headings indented by 1–3 spaces (valid CommonMark): toggle-H2 on `  ## Title` removes the heading instead of emitting `## ## Title`, toggling a different level swaps cleanly, and promote/demote no longer silently no-op on indented headings.
- Detection uses literal spaces (` {0,3}`), not `\s` — tab-indented and 4+-space-indented lines are indented code blocks and keep their existing non-heading behavior. Headings are re-emitted without the indent, matching the existing strip-on-emit behavior.
- Added 7 unit tests to `src/test/suite/toggle.test.ts` covering same-level toggle-off, level swap without double-hashing, 3-space boundary, promote/demote with indent, and 4-space code-indent no-ops. CHANGELOG `### Fixed` entry added under `[Unreleased]`.

No README update: bug fix restoring documented behavior; no new command, setting, or keybinding.

Gates: `npx tsc --noEmit` clean, `node esbuild.js --production` clean, `npm test` 208 passing / 0 failing.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)