### PR TITLE
Insert Horizontal Rule creates a setext heading instead of a rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 - Tab-selecting a cell in a right- or center-aligned column now selects only the cell's content, not the surrounding alignment padding — so typing over the selection no longer eats the padding and misaligns the table ([#106](https://github.com/dvlprlife/Markdown-Foundry/pull/106)).
 - `Paste Image` no longer silently overwrites an existing image when the generated filename collides (e.g. two pastes within the same second) — it now appends `-1`, `-2`, … until the name is free ([#108](https://github.com/dvlprlife/Markdown-Foundry/pull/108)).
 - `Insert Link to File`, `Paste Link`, and `Paste Image` now wrap link destinations containing spaces or parentheses in angle brackets (`[text](<my file.docx>)`), so links to such paths render correctly instead of producing broken Markdown ([#109](https://github.com/dvlprlife/Markdown-Foundry/pull/109)).
+- `Insert Horizontal Rule` no longer turns the current line into a setext heading — a blank line now separates the text from the inserted `---`, and the insertion respects the document's line endings (CRLF documents get `\r\n`) ([#119](https://github.com/dvlprlife/Markdown-Foundry/issues/119)).
 
 ## [0.5.0] - 2026-05-09
 

--- a/src/format/commands.ts
+++ b/src/format/commands.ts
@@ -147,8 +147,22 @@ export async function toggleTaskListCommand(): Promise<void> {
 export async function insertHorizontalRuleCommand(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
   if (!editor) {return;}
+  const document = editor.document;
+  const eol = document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
   const cursorLine = editor.selection.active.line;
-  const line = editor.document.lineAt(cursorLine);
+  const line = document.lineAt(cursorLine);
   const insertPos = new vscode.Position(cursorLine, line.text.length);
-  await editor.edit((edit) => edit.insert(insertPos, '\n---'));
+
+  // The line immediately above the inserted --- must be blank (or the rule
+  // must sit at document start); otherwise CommonMark parses it as a setext
+  // heading underline for the text above.
+  let inserted: string;
+  if (!line.isEmptyOrWhitespace) {
+    inserted = eol + eol + '---';
+  } else if (cursorLine > 0 && !document.lineAt(cursorLine - 1).isEmptyOrWhitespace) {
+    inserted = eol + '---';
+  } else {
+    inserted = '---';
+  }
+  await editor.edit((edit) => edit.insert(insertPos, inserted));
 }

--- a/src/test/suite/horizontalRule.test.ts
+++ b/src/test/suite/horizontalRule.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { insertHorizontalRuleCommand } from '../../format/commands';
+
+async function invokeOnLine(content: string, line: number): Promise<vscode.TextDocument> {
+  const doc = await vscode.workspace.openTextDocument({ language: 'markdown', content });
+  const editor = await vscode.window.showTextDocument(doc);
+  const pos = new vscode.Position(line, doc.lineAt(line).text.length);
+  editor.selection = new vscode.Selection(pos, pos);
+  await insertHorizontalRuleCommand();
+  return doc;
+}
+
+suite('format: insertHorizontalRuleCommand', () => {
+  test('non-empty line gets a blank line before the rule (no setext heading)', async () => {
+    const doc = await invokeOnLine('hello\nworld', 0);
+    assert.strictEqual(doc.getText(), 'hello\n\n---\nworld');
+  });
+
+  test('non-empty last line without trailing newline', async () => {
+    const doc = await invokeOnLine('para\nhello', 1);
+    assert.strictEqual(doc.getText(), 'para\nhello\n\n---');
+  });
+
+  test('empty line directly below text keeps it as the separator and puts the rule below', async () => {
+    const doc = await invokeOnLine('hello\n\nmore', 1);
+    assert.strictEqual(doc.getText(), 'hello\n\n---\nmore');
+  });
+
+  test('empty line with a blank line above takes the rule in place', async () => {
+    const doc = await invokeOnLine('text\n\n\nafter', 2);
+    assert.strictEqual(doc.getText(), 'text\n\n---\nafter');
+  });
+
+  test('empty line at document start takes the rule in place', async () => {
+    const doc = await invokeOnLine('\nbody', 0);
+    assert.strictEqual(doc.getText(), '---\nbody');
+  });
+
+  test('whitespace-only line counts as blank', async () => {
+    const doc = await invokeOnLine('hello\n \nmore', 1);
+    assert.strictEqual(doc.getText(), 'hello\n \n---\nmore');
+  });
+
+  test('CRLF document: non-empty line inserts \\r\\n separators', async () => {
+    const doc = await invokeOnLine('hello\r\nworld', 0);
+    assert.strictEqual(doc.getText(), 'hello\r\n\r\n---\r\nworld');
+  });
+
+  test('CRLF document: empty line below text inserts \\r\\n before the rule', async () => {
+    const doc = await invokeOnLine('hello\r\n\r\nmore', 1);
+    assert.strictEqual(doc.getText(), 'hello\r\n\r\n---\r\nmore');
+  });
+});


### PR DESCRIPTION
## Summary
- `insertHorizontalRuleCommand` now guarantees the line above the inserted `---` is blank (or the rule sits at document start), so it renders as a thematic break instead of a setext H2 underline for the text above.
- Insertion uses the document EOL (`\r\n` in CRLF documents) instead of a hardcoded `\n`.
- Added `src/test/suite/horizontalRule.test.ts` — 8 integration tests covering non-empty line, empty line below text, empty line with blank above, document start, whitespace-only line, and CRLF variants; plus a CHANGELOG `### Fixed` entry under `[Unreleased]`.

No README change: no new/removed command, keybinding, or setting — the existing `Insert Horizontal Rule` description remains accurate.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)