### PR TITLE
Move Row/Column: cursor doesn't follow the moved row, repeat invocations ping-pong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Fixed
 
+- Table row/column commands now reposition the cursor to follow the edit: `Move Row/Column` keeps the caret on the moved row or column (so repeated invocations keep moving the same content instead of ping-ponging), `Insert Row/Column` places it in the new row or column, and `Delete Row/Column` clamps it to what remains ([#130](https://github.com/dvlprlife/Markdown-Foundry/pull/130)).
 - `Sort Table by Column` now shows an explanatory message when invoked with the cursor on the separator row, instead of doing nothing silently ([#104](https://github.com/dvlprlife/Markdown-Foundry/pull/104)).
 - Table-cell `Tab` navigation no longer overrides accepting an inline suggestion (e.g. Copilot ghost text) — the keybinding now also requires `!inlineSuggestionVisible` ([#105](https://github.com/dvlprlife/Markdown-Foundry/pull/105)).
 - Tab-selecting a cell in a right- or center-aligned column now selects only the cell's content, not the surrounding alignment padding — so typing over the selection no longer eats the padding and misaligns the table ([#106](https://github.com/dvlprlife/Markdown-Foundry/pull/106)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Fixed
 
-- Table row/column commands now reposition the cursor to follow the edit: `Move Row/Column` keeps the caret on the moved row or column (so repeated invocations keep moving the same content instead of ping-ponging), `Insert Row/Column` places it in the new row or column, and `Delete Row/Column` clamps it to what remains ([#130](https://github.com/dvlprlife/Markdown-Foundry/pull/130)).
 - `Sort Table by Column` now shows an explanatory message when invoked with the cursor on the separator row, instead of doing nothing silently ([#104](https://github.com/dvlprlife/Markdown-Foundry/pull/104)).
 - Table-cell `Tab` navigation no longer overrides accepting an inline suggestion (e.g. Copilot ghost text) — the keybinding now also requires `!inlineSuggestionVisible` ([#105](https://github.com/dvlprlife/Markdown-Foundry/pull/105)).
 - Tab-selecting a cell in a right- or center-aligned column now selects only the cell's content, not the surrounding alignment padding — so typing over the selection no longer eats the padding and misaligns the table ([#106](https://github.com/dvlprlife/Markdown-Foundry/pull/106)).
@@ -16,6 +15,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 - Heading toggle and promote/demote now recognize headings indented by 1–3 spaces (valid CommonMark) — toggling `  ## Title` removes or swaps the heading instead of producing `## ## Title`, and promote/demote no longer silently no-op on indented headings. Lines indented 4+ spaces are still treated as code, not headings ([#127](https://github.com/dvlprlife/Markdown-Foundry/pull/127)).
 - `Insert Horizontal Rule` no longer turns the current line into a setext heading — a blank line now separates the text from the inserted `---`, and the insertion respects the document's line endings (CRLF documents get `\r\n`) ([#128](https://github.com/dvlprlife/Markdown-Foundry/pull/128)).
 - Multi-line formatting toggles (blockquote, block code, bullet/numbered/task list) no longer rewrite CRLF line endings to LF — the replaced lines now keep the document's line endings ([#129](https://github.com/dvlprlife/Markdown-Foundry/pull/129)).
+- Table row/column commands now reposition the cursor to follow the edit: `Move Row/Column` keeps the caret on the moved row or column (so repeated invocations keep moving the same content instead of ping-ponging), `Insert Row/Column` places it in the new row or column, and `Delete Row/Column` clamps it to what remains ([#130](https://github.com/dvlprlife/Markdown-Foundry/pull/130)).
 
 ## [0.5.0] - 2026-05-09
 

--- a/src/table/commands/rowColumn.ts
+++ b/src/table/commands/rowColumn.ts
@@ -2,14 +2,20 @@ import * as vscode from 'vscode';
 import { locateTable, cursorToTableCoords } from '../locator';
 import { parseTable } from '../parser';
 import { formatTable } from '../formatter';
-import { Alignment, TableModel } from '../types';
+import { computeCellRange } from './navigate';
+import { Alignment, TableCursor, TableModel } from '../types';
 
 /**
  * Shared helper: load the table at the cursor, run a transform on the model,
- * then write it back. Returns the new cursor position (caller can ignore).
+ * then write it back. If the transform returns a cursor, the selection is
+ * repositioned to a collapsed caret at that cell's content start so repeated
+ * invocations keep operating on the same (moved) content.
  */
 async function transformTable(
-  transform: (model: TableModel, coords: { rowIndex: number; columnIndex: number }) => TableModel | null
+  transform: (
+    model: TableModel,
+    coords: TableCursor
+  ) => { model: TableModel; cursor?: TableCursor } | null
 ): Promise<void> {
   const editor = vscode.window.activeTextEditor;
   if (!editor) {return;}
@@ -29,13 +35,35 @@ async function transformTable(
   }
 
   const model = parseTable(document, location);
-  const newModel = transform(model, coords);
-  if (!newModel) {return;}
+  const result = transform(model, coords);
+  if (!result) {return;}
 
-  const formatted = formatTable(newModel);
-  await editor.edit((edit) => {
+  const formatted = formatTable(result.model);
+  const applied = await editor.edit((edit) => {
     edit.replace(location.range, formatted);
   });
+
+  if (applied && result.cursor) {
+    placeCaretInCell(editor, location.headerLine, result.cursor);
+  }
+}
+
+function placeCaretInCell(
+  editor: vscode.TextEditor,
+  headerLine: number,
+  cursor: TableCursor
+): void {
+  const lineNumber =
+    cursor.rowIndex === -1 ? headerLine : headerLine + 2 + cursor.rowIndex;
+  if (lineNumber >= editor.document.lineCount) {return;}
+
+  const lineText = editor.document.lineAt(lineNumber).text;
+  const range = computeCellRange(lineText, cursor.columnIndex);
+  if (!range) {return;}
+
+  const caret = new vscode.Position(lineNumber, range.start);
+  editor.selection = new vscode.Selection(caret, caret);
+  editor.revealRange(new vscode.Range(caret, caret));
 }
 
 /** Get the default alignment from user config. */
@@ -45,34 +73,37 @@ function defaultAlignment(): Alignment {
 }
 
 export async function insertRowAboveCommand(): Promise<void> {
-  await transformTable((model, { rowIndex }) => {
+  await transformTable((model, { rowIndex, columnIndex }) => {
     const newRow = Array(model.headers.length).fill('');
     const insertAt = Math.max(0, rowIndex); // header row treated as index 0
     const rows = [...model.rows];
     rows.splice(insertAt, 0, newRow);
-    return { ...model, rows };
+    return { model: { ...model, rows }, cursor: { rowIndex: insertAt, columnIndex } };
   });
 }
 
 export async function insertRowBelowCommand(): Promise<void> {
-  await transformTable((model, { rowIndex }) => {
+  await transformTable((model, { rowIndex, columnIndex }) => {
     const newRow = Array(model.headers.length).fill('');
     const insertAt = rowIndex < 0 ? 0 : rowIndex + 1;
     const rows = [...model.rows];
     rows.splice(insertAt, 0, newRow);
-    return { ...model, rows };
+    return { model: { ...model, rows }, cursor: { rowIndex: insertAt, columnIndex } };
   });
 }
 
 export async function insertColumnLeftCommand(): Promise<void> {
-  await transformTable((model, { columnIndex }) => {
-    return insertColumnAt(model, columnIndex);
+  await transformTable((model, { rowIndex, columnIndex }) => {
+    return { model: insertColumnAt(model, columnIndex), cursor: { rowIndex, columnIndex } };
   });
 }
 
 export async function insertColumnRightCommand(): Promise<void> {
-  await transformTable((model, { columnIndex }) => {
-    return insertColumnAt(model, columnIndex + 1);
+  await transformTable((model, { rowIndex, columnIndex }) => {
+    return {
+      model: insertColumnAt(model, columnIndex + 1),
+      cursor: { rowIndex, columnIndex: columnIndex + 1 }
+    };
   });
 }
 
@@ -91,7 +122,7 @@ function insertColumnAt(model: TableModel, index: number): TableModel {
 }
 
 export async function deleteRowCommand(): Promise<void> {
-  await transformTable((model, { rowIndex }) => {
+  await transformTable((model, { rowIndex, columnIndex }) => {
     if (rowIndex < 0) {
       vscode.window.showInformationMessage('Markdown Foundry: cannot delete the header row.');
       return null;
@@ -99,12 +130,13 @@ export async function deleteRowCommand(): Promise<void> {
     if (model.rows.length === 0) {return null;}
     const rows = [...model.rows];
     rows.splice(rowIndex, 1);
-    return { ...model, rows };
+    const cursorRow = rows.length === 0 ? -1 : Math.min(rowIndex, rows.length - 1);
+    return { model: { ...model, rows }, cursor: { rowIndex: cursorRow, columnIndex } };
   });
 }
 
 export async function deleteColumnCommand(): Promise<void> {
-  await transformTable((model, { columnIndex }) => {
+  await transformTable((model, { rowIndex, columnIndex }) => {
     if (model.headers.length <= 1) {
       vscode.window.showInformationMessage('Markdown Foundry: cannot delete the last column.');
       return null;
@@ -118,39 +150,48 @@ export async function deleteColumnCommand(): Promise<void> {
       r.splice(columnIndex, 1);
       return r;
     });
-    return { ...model, headers, alignments, rows };
+    return {
+      model: { ...model, headers, alignments, rows },
+      cursor: { rowIndex, columnIndex: Math.min(columnIndex, headers.length - 1) }
+    };
   });
 }
 
 export async function moveRowUpCommand(): Promise<void> {
-  await transformTable((model, { rowIndex }) => {
+  await transformTable((model, { rowIndex, columnIndex }) => {
     if (rowIndex <= 0) {return null;}
     const rows = [...model.rows];
     [rows[rowIndex - 1], rows[rowIndex]] = [rows[rowIndex], rows[rowIndex - 1]];
-    return { ...model, rows };
+    return { model: { ...model, rows }, cursor: { rowIndex: rowIndex - 1, columnIndex } };
   });
 }
 
 export async function moveRowDownCommand(): Promise<void> {
-  await transformTable((model, { rowIndex }) => {
+  await transformTable((model, { rowIndex, columnIndex }) => {
     if (rowIndex < 0 || rowIndex >= model.rows.length - 1) {return null;}
     const rows = [...model.rows];
     [rows[rowIndex + 1], rows[rowIndex]] = [rows[rowIndex], rows[rowIndex + 1]];
-    return { ...model, rows };
+    return { model: { ...model, rows }, cursor: { rowIndex: rowIndex + 1, columnIndex } };
   });
 }
 
 export async function moveColumnLeftCommand(): Promise<void> {
-  await transformTable((model, { columnIndex }) => {
+  await transformTable((model, { rowIndex, columnIndex }) => {
     if (columnIndex <= 0) {return null;}
-    return swapColumns(model, columnIndex, columnIndex - 1);
+    return {
+      model: swapColumns(model, columnIndex, columnIndex - 1),
+      cursor: { rowIndex, columnIndex: columnIndex - 1 }
+    };
   });
 }
 
 export async function moveColumnRightCommand(): Promise<void> {
-  await transformTable((model, { columnIndex }) => {
+  await transformTable((model, { rowIndex, columnIndex }) => {
     if (columnIndex >= model.headers.length - 1) {return null;}
-    return swapColumns(model, columnIndex, columnIndex + 1);
+    return {
+      model: swapColumns(model, columnIndex, columnIndex + 1),
+      cursor: { rowIndex, columnIndex: columnIndex + 1 }
+    };
   });
 }
 

--- a/src/test/suite/rowColumn.test.ts
+++ b/src/test/suite/rowColumn.test.ts
@@ -1,0 +1,187 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import {
+  insertRowAboveCommand,
+  insertRowBelowCommand,
+  insertColumnLeftCommand,
+  insertColumnRightCommand,
+  deleteRowCommand,
+  deleteColumnCommand,
+  moveRowUpCommand,
+  moveRowDownCommand,
+  moveColumnLeftCommand,
+  moveColumnRightCommand
+} from '../../table/commands/rowColumn';
+import { computeCellRange } from '../../table/commands/navigate';
+
+const TABLE = [
+  '| A | B | C |',
+  '| --- | --- | --- |',
+  '| a1 | b1 | c1 |',
+  '| a2 | b2 | c2 |',
+  '| a3 | b3 | c3 |'
+].join('\n');
+
+async function openTable(content: string = TABLE): Promise<vscode.TextEditor> {
+  const doc = await vscode.workspace.openTextDocument({ language: 'markdown', content });
+  return vscode.window.showTextDocument(doc);
+}
+
+function placeCursorInCell(editor: vscode.TextEditor, line: number, columnIndex: number): void {
+  const range = computeCellRange(editor.document.lineAt(line).text, columnIndex);
+  assert.ok(range, `no cell ${columnIndex} on line ${line}`);
+  const pos = new vscode.Position(line, range.start);
+  editor.selection = new vscode.Selection(pos, pos);
+}
+
+function cellAt(document: vscode.TextDocument, line: number, columnIndex: number): string {
+  const lineText = document.lineAt(line).text;
+  const range = computeCellRange(lineText, columnIndex);
+  assert.ok(range, `no cell ${columnIndex} on line ${line}`);
+  return lineText.slice(range.start, range.end);
+}
+
+function assertCaretInCell(editor: vscode.TextEditor, line: number, columnIndex: number): void {
+  assert.ok(editor.selection.isEmpty, 'caret should be collapsed (no selection)');
+  const range = computeCellRange(editor.document.lineAt(line).text, columnIndex);
+  assert.ok(range, `no cell ${columnIndex} on line ${line}`);
+  assert.strictEqual(editor.selection.active.line, line, 'caret line');
+  assert.strictEqual(editor.selection.active.character, range.start, 'caret at cell content start');
+}
+
+suite('rowColumn: move commands keep the cursor on the moved content', () => {
+  test('move row up follows the moved row, same column', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 3, 1); // a2 row, column B
+    await moveRowUpCommand();
+    assert.strictEqual(cellAt(editor.document, 2, 0), 'a2');
+    assert.strictEqual(cellAt(editor.document, 3, 0), 'a1');
+    assertCaretInCell(editor, 2, 1);
+  });
+
+  test('move row up twice moves the same row two positions', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 4, 2); // a3 row, column C
+    await moveRowUpCommand();
+    await moveRowUpCommand();
+    assert.strictEqual(cellAt(editor.document, 2, 0), 'a3');
+    assert.strictEqual(cellAt(editor.document, 3, 0), 'a1');
+    assert.strictEqual(cellAt(editor.document, 4, 0), 'a2');
+    assertCaretInCell(editor, 2, 2);
+  });
+
+  test('move row down twice moves the same row two positions', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 2, 0); // a1 row
+    await moveRowDownCommand();
+    await moveRowDownCommand();
+    assert.strictEqual(cellAt(editor.document, 2, 0), 'a2');
+    assert.strictEqual(cellAt(editor.document, 3, 0), 'a3');
+    assert.strictEqual(cellAt(editor.document, 4, 0), 'a1');
+    assertCaretInCell(editor, 4, 0);
+  });
+
+  test('move column left twice moves the same column two positions', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 3, 2); // a2 row, column C
+    await moveColumnLeftCommand();
+    await moveColumnLeftCommand();
+    assert.strictEqual(cellAt(editor.document, 0, 0), 'C');
+    assert.strictEqual(cellAt(editor.document, 3, 0), 'c2');
+    assertCaretInCell(editor, 3, 0);
+  });
+
+  test('move column right twice moves the same column two positions', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 2, 0); // a1 row, column A
+    await moveColumnRightCommand();
+    await moveColumnRightCommand();
+    assert.strictEqual(cellAt(editor.document, 0, 2), 'A');
+    assert.strictEqual(cellAt(editor.document, 2, 2), 'a1');
+    assertCaretInCell(editor, 2, 2);
+  });
+
+  test('move column from the header row follows the moved column', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 0, 1); // header, column B
+    await moveColumnRightCommand();
+    assert.strictEqual(cellAt(editor.document, 0, 2), 'B');
+    assert.strictEqual(cellAt(editor.document, 0, 1), 'C');
+    assertCaretInCell(editor, 0, 2);
+  });
+});
+
+suite('rowColumn: insert commands place the cursor in the new row/column', () => {
+  test('insert row above puts the caret in the inserted row, same column', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 3, 1); // a2 row, column B
+    await insertRowAboveCommand();
+    assert.strictEqual(cellAt(editor.document, 3, 0), '');
+    assert.strictEqual(cellAt(editor.document, 4, 0), 'a2');
+    assertCaretInCell(editor, 3, 1);
+  });
+
+  test('insert row below puts the caret in the inserted row, same column', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 3, 2); // a2 row, column C
+    await insertRowBelowCommand();
+    assert.strictEqual(cellAt(editor.document, 4, 0), '');
+    assert.strictEqual(cellAt(editor.document, 5, 0), 'a3');
+    assertCaretInCell(editor, 4, 2);
+  });
+
+  test('insert column left puts the caret in the new column, same row', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 3, 1); // a2 row, column B
+    await insertColumnLeftCommand();
+    assert.strictEqual(cellAt(editor.document, 3, 1), '');
+    assert.strictEqual(cellAt(editor.document, 3, 2), 'b2');
+    assertCaretInCell(editor, 3, 1);
+  });
+
+  test('insert column right puts the caret in the new column, same row', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 2, 1); // a1 row, column B
+    await insertColumnRightCommand();
+    assert.strictEqual(cellAt(editor.document, 2, 2), '');
+    assert.strictEqual(cellAt(editor.document, 2, 1), 'b1');
+    assertCaretInCell(editor, 2, 2);
+  });
+});
+
+suite('rowColumn: delete commands clamp the cursor to what remains', () => {
+  test('delete middle row keeps the caret at the same row index, same column', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 3, 1); // a2 row, column B
+    await deleteRowCommand();
+    assert.strictEqual(cellAt(editor.document, 2, 0), 'a1');
+    assert.strictEqual(cellAt(editor.document, 3, 0), 'a3');
+    assertCaretInCell(editor, 3, 1);
+  });
+
+  test('delete last row clamps the caret to the new last row', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 4, 0); // a3 row
+    await deleteRowCommand();
+    assert.strictEqual(editor.document.lineCount, 4);
+    assert.strictEqual(cellAt(editor.document, 3, 0), 'a2');
+    assertCaretInCell(editor, 3, 0);
+  });
+
+  test('delete the only body row moves the caret to the header row', async () => {
+    const editor = await openTable(['| A | B |', '| --- | --- |', '| a1 | b1 |'].join('\n'));
+    placeCursorInCell(editor, 2, 1);
+    await deleteRowCommand();
+    assert.strictEqual(editor.document.lineCount, 2);
+    assertCaretInCell(editor, 0, 1);
+  });
+
+  test('delete last column clamps the caret to the new last column', async () => {
+    const editor = await openTable();
+    placeCursorInCell(editor, 3, 2); // a2 row, column C
+    await deleteColumnCommand();
+    assert.strictEqual(cellAt(editor.document, 0, 1), 'B');
+    assert.strictEqual(cellAt(editor.document, 3, 1), 'b2');
+    assertCaretInCell(editor, 3, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- `transformTable` transforms now return `{ model, cursor? }`; after a successful edit the selection is repositioned to a collapsed caret at the target cell's content start (via `computeCellRange`) and revealed
- Move Row/Column follows the moved content so repeat invocations chain; Insert Row/Column lands in the new row/column; Delete Row/Column clamps to the remaining index (header row when no body rows remain)
- 14 integration tests in `src/test/suite/rowColumn.test.ts` exercise the full parse → transform → format pipeline against a real editor and assert the resulting selection, including double-invocation chaining for all four move commands

No README change: the fix restores expected behavior for already-documented commands and the README does not describe cursor placement.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)