### PR TITLE
release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-07
+
 ### Changed
 
 - Align Table moved from `Ctrl/Cmd+Shift+T` to `Shift+Alt+T` so it no longer shadows VS Code's Reopen Closed Editor in Markdown files ([#133](https://github.com/dvlprlife/Markdown-Foundry/pull/133)).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdfoundry",
   "displayName": "Markdown Foundry",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "dvlprlife",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

- Roll `[Unreleased]` into `[0.6.0] - 2026-07-07` and add a fresh empty `[Unreleased]` section
- Bump `package.json` version 0.5.0 → 0.6.0

Ships 14 bug fixes (table navigation, formatting toggles, TOC slugs, image/link insertion, locator GFM support) and the Align Table rebind to `Shift+Alt+T`.

Release housekeeping only — no issue, matching the v0.5.0 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)