### PR TITLE
Table editing commands should not re-align the whole table; add markdownFoundry.alignOnEdit (default false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 - Table editing commands no longer re-align the whole table. Insert/Delete/Move Row or Column, Sort Table by Column, and the row added by `Tab` or `Enter` at the end of a table now edit surgically and leave the padding of every untouched cell exactly as it was — an inserted row mirrors its neighbor's cell widths, and an inserted column adds an empty `|  |` cell. Align explicitly with `Align Table` (`Shift+Alt+T`), or opt back in with `markdownFoundry.alignOnEdit` ([#136](https://github.com/dvlprlife/Markdown-Foundry/pull/136)).
 
+### Fixed
+
+- `Move Column Left` no longer throws when the cursor sits in a cell past the header's last column (possible when a body row has more cells than the header) — it is now a no-op, like `Move Column Right` already was ([#136](https://github.com/dvlprlife/Markdown-Foundry/pull/136)).
+- `Delete Column` with the cursor in a cell past the header's last column no longer rewrites the table — there is no column there to delete, so it no longer dirties the buffer or pushes an undo step ([#136](https://github.com/dvlprlife/Markdown-Foundry/pull/136)).
+
 ## [0.6.0] - 2026-07-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+### Added
+
+- `markdownFoundry.alignOnEdit` (default `false`) — set it to `true` to restore the previous behavior of re-aligning the whole table after every table editing command ([#136](https://github.com/dvlprlife/Markdown-Foundry/pull/136)).
+
+### Changed
+
+- Table editing commands no longer re-align the whole table. Insert/Delete/Move Row or Column, Sort Table by Column, and the row added by `Tab` or `Enter` at the end of a table now edit surgically and leave the padding of every untouched cell exactly as it was — an inserted row mirrors its neighbor's cell widths, and an inserted column adds an empty `|  |` cell. Align explicitly with `Align Table` (`Shift+Alt+T`), or opt back in with `markdownFoundry.alignOnEdit` ([#136](https://github.com/dvlprlife/Markdown-Foundry/pull/136)).
+
 ## [0.6.0] - 2026-07-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ All other commands are available through the Command Palette (search for "Markdo
 | Setting | Default | Description |
 | --- | --- | --- |
 | `markdownFoundry.alignOnSave` | `false` | Align all tables in the file when saving. |
+| `markdownFoundry.alignOnEdit` | `false` | Re-align the whole table after a table editing command. Off by default, so edits keep your existing cell padding. |
 | `markdownFoundry.defaultAlignment` | `"left"` | Alignment for new columns. |
 | `markdownFoundry.imageFolder` | `"images"` | Folder (relative to the file) where pasted images are saved. |
 | `markdownFoundry.imageNameFormat` | `"image-${timestamp}"` | Template for pasted image filenames. Tokens: `${timestamp}`, `${date}`, `${filename}`. |

--- a/package.json
+++ b/package.json
@@ -182,6 +182,11 @@
           "default": false,
           "description": "Automatically align all Markdown tables in the file when it is saved."
         },
+        "markdownFoundry.alignOnEdit": {
+          "type": "boolean",
+          "default": false,
+          "description": "Re-align the whole table after a table editing command (insert/delete/move row or column, sort, and the row added by Tab or Enter at the end of a table). When off, edits preserve the existing cell padding; use the Align Table command to align explicitly."
+        },
         "markdownFoundry.defaultAlignment": {
           "type": "string",
           "enum": ["left", "center", "right"],

--- a/src/table/cells.ts
+++ b/src/table/cells.ts
@@ -169,6 +169,10 @@ function hasTrailingPipe(line: string): boolean {
  * Clone a row's pipe structure with every cell blanked, keeping each cell's
  * rendered width so the new row's pipes line up with the row it was cloned
  * from — however that row happens to be padded.
+ *
+ * A blanked clone of a row without a leading or trailing pipe (`a | b`) needs
+ * one: with every cell now whitespace, the outermost pipes are all that keeps
+ * the cells addressable. cellCount is invariant under this function.
  */
 export function blankRowLike(line: string): string {
   const spans = cellSpans(line);
@@ -176,14 +180,17 @@ export function blankRowLike(line: string): string {
     return line;
   }
 
-  let out = '';
-  let cursor = 0;
-  for (const span of spans) {
-    out += line.slice(cursor, span.start);
-    out += ' '.repeat(visualWidth(line.slice(span.start, span.end)));
-    cursor = span.end;
+  const first = spans[0];
+  const last = spans[spans.length - 1];
+
+  let out = line.slice(0, first.start) + (hasLeadingPipe(line) ? '' : '|');
+  for (let i = 0; i < spans.length; i++) {
+    if (i > 0) {
+      out += line.slice(spans[i - 1].end, spans[i].start);
+    }
+    out += ' '.repeat(visualWidth(line.slice(spans[i].start, spans[i].end)));
   }
-  return out + line.slice(cursor);
+  return out + (hasTrailingPipe(line) ? '' : '|') + line.slice(last.end);
 }
 
 function firstNonSpace(line: string): number {

--- a/src/table/cells.ts
+++ b/src/table/cells.ts
@@ -106,23 +106,14 @@ function appendCell(line: string, text: string): string {
 
 /** Remove the cell at `index`, along with one of its delimiting pipes. */
 export function removeCell(line: string, index: number): string {
-  const spans = cellSpans(line);
-  if (index < 0 || index >= spans.length) {
+  const row = rowShape(line);
+  if (!row || index < 0 || index >= row.cells.length) {
     return line;
   }
 
-  if (spans.length === 1) {
-    return keepIndent(line, line.slice(0, spans[0].start) + line.slice(spans[0].end));
-  }
-
-  if (index === spans.length - 1) {
-    return line.slice(0, spans[index - 1].end) + line.slice(spans[index].end);
-  }
-
-  return keepIndent(
-    line,
-    line.slice(0, spans[index].start) + line.slice(spans[index + 1].start)
-  );
+  const cells = [...row.cells];
+  cells.splice(index, 1);
+  return renderRow({ ...row, cells });
 }
 
 /** Swap the raw text (padding included) of two cells. */
@@ -130,32 +121,78 @@ export function swapCells(line: string, a: number, b: number): string {
   if (a === b) {
     return line;
   }
-  const spans = cellSpans(line);
-  const low = Math.min(a, b);
-  const high = Math.max(a, b);
-  if (low < 0 || high >= spans.length) {
+  const row = rowShape(line);
+  if (!row || Math.min(a, b) < 0 || Math.max(a, b) >= row.cells.length) {
     return line;
   }
 
-  const first = spans[low];
-  const second = spans[high];
-  return keepIndent(
-    line,
-    line.slice(0, first.start) +
-      line.slice(second.start, second.end) +
-      line.slice(first.end, second.start) +
-      line.slice(first.start, first.end) +
-      line.slice(second.end)
-  );
+  const cells = [...row.cells];
+  [cells[a], cells[b]] = [cells[b], cells[a]];
+  return renderRow({ ...row, cells });
 }
 
 /**
- * Re-anchor a transformed line to the source's indent. On a row without a
- * leading pipe the first cell's span starts at the indent, so moving another
- * cell's padding into that slot would silently re-indent the whole table.
+ * A row taken apart into the pieces a transform may reorder, so it can be put
+ * back together with delimiters that still fit what the cells became.
  */
-function keepIndent(source: string, result: string): string {
-  return source.slice(0, firstNonSpace(source)) + result.slice(firstNonSpace(result));
+interface RowShape {
+  indent: string;
+  /** Is there a pipe before the first cell? */
+  leading: boolean;
+  /** Raw cell text, padding included. */
+  cells: string[];
+  /** Is there a pipe after the last cell? */
+  closing: boolean;
+  /** Whitespace trailing the row. */
+  tail: string;
+}
+
+function rowShape(line: string): RowShape | null {
+  const spans = cellSpans(line);
+  if (spans.length === 0) {
+    return null;
+  }
+  const last = spans[spans.length - 1];
+  const closing = hasClosingPipe(line, spans);
+  return {
+    indent: line.slice(0, firstNonSpace(line)),
+    leading: hasLeadingPipe(line),
+    cells: spans.map((span) => line.slice(span.start, span.end)),
+    closing,
+    tail: line.slice(closing ? last.end + 1 : last.end)
+  };
+}
+
+/**
+ * Reassemble a row, adding the delimiters its cells now need. A blank cell at
+ * either end is only addressable if a pipe holds it open, and a row with no
+ * unescaped pipe left is no longer a table row at all — it would render as a
+ * paragraph, or worse, as a setext heading.
+ */
+function renderRow(row: RowShape): string {
+  const { cells, indent, tail } = row;
+  if (cells.length === 0) {
+    return indent + '||' + tail;
+  }
+
+  const single = cells.length < 2;
+  const leading = row.leading || single || isBlank(cells[0]);
+  const closing = row.closing || single || isBlank(cells[cells.length - 1]);
+
+  // Without a leading pipe the first cell starts at the indent, so any padding
+  // it picked up from another cell would be read as indentation.
+  const body = [...cells];
+  if (!leading) {
+    body[0] = body[0].replace(/^\s+/, '');
+  }
+
+  return (
+    indent + (leading ? '|' : '') + body.join('|') + (closing ? '|' : '') + tail
+  );
+}
+
+function isBlank(text: string): boolean {
+  return text.trim() === '';
 }
 
 function hasLeadingPipe(line: string): boolean {

--- a/src/table/cells.ts
+++ b/src/table/cells.ts
@@ -74,18 +74,20 @@ export function insertCell(line: string, index: number, text: string): string {
     return line + '|' + text;
   }
 
-  let out = line;
-  for (let n = spans.length; n < index; n++) {
-    out = appendCell(out, text);
-  }
-  return appendCell(out, text);
+  return appendCell(padCells(line, index, text), text);
 }
 
 /** Grow the line to `count` cells by appending cells of raw text `fill`. */
 export function padCells(line: string, count: number, fill: string): string {
   let out = line;
-  for (let n = cellCount(out); n < count; n++) {
+  let grown = cellCount(out);
+  while (grown < count) {
     out = appendCell(out, fill);
+    const next = cellCount(out);
+    if (next <= grown) {
+      return out;
+    }
+    grown = next;
   }
   return out;
 }
@@ -97,7 +99,7 @@ function appendCell(line: string, text: string): string {
   }
   // A row without a trailing pipe (`a | b`) needs one, or an appended blank
   // cell reads as trailing whitespace and is lost.
-  const closer = hasTrailingPipe(line) ? '' : '|';
+  const closer = hasClosingPipe(line, spans) ? '' : '|';
   const at = spans[spans.length - 1].end;
   return line.slice(0, at) + '|' + text + closer + line.slice(at);
 }
@@ -160,9 +162,13 @@ function hasLeadingPipe(line: string): boolean {
   return line[firstNonSpace(line)] === '|';
 }
 
-function hasTrailingPipe(line: string): boolean {
-  const end = lastNonSpaceEnd(line);
-  return end > firstNonSpace(line) && line[end - 1] === '|';
+/**
+ * Does a delimiter close the last cell? Sniffing the final character would
+ * misread a row that legitimately ends in an escaped pipe (`| a | b \|`),
+ * whose last cell runs to the end of the line with nothing closing it.
+ */
+function hasClosingPipe(line: string, spans: CellSpan[]): boolean {
+  return spans.length > 0 && spans[spans.length - 1].end < lastNonSpaceEnd(line);
 }
 
 /**
@@ -190,7 +196,7 @@ export function blankRowLike(line: string): string {
     }
     out += ' '.repeat(visualWidth(line.slice(spans[i].start, spans[i].end)));
   }
-  return out + (hasTrailingPipe(line) ? '' : '|') + line.slice(last.end);
+  return out + (hasClosingPipe(line, spans) ? '' : '|') + line.slice(last.end);
 }
 
 function firstNonSpace(line: string): number {

--- a/src/table/cells.ts
+++ b/src/table/cells.ts
@@ -1,0 +1,203 @@
+import { visualWidth } from './formatter';
+
+/**
+ * Character offsets of a single cell's raw text — the span between its
+ * delimiting pipes, padding included.
+ */
+export interface CellSpan {
+  start: number;
+  end: number;
+}
+
+/**
+ * Raw-line cell primitives. These operate on the source text of a table row
+ * and leave every byte outside the edited cell untouched, so table edits can
+ * preserve the author's existing padding.
+ *
+ * Cell indexing matches `splitRow` in parser.ts and `computeCellRange` in
+ * commands/navigate.ts: leading indent is skipped, a leading pipe is a
+ * delimiter rather than a separator, escaped pipes (\|) are content, and a
+ * row with no trailing pipe ends its last cell at the line's end.
+ */
+export function cellSpans(line: string): CellSpan[] {
+  const start = firstNonSpace(line);
+  const end = Math.max(lastNonSpaceEnd(line), start);
+
+  let i = start;
+  if (i < end && line[i] === '|') {
+    i++;
+  }
+
+  const spans: CellSpan[] = [];
+  let cellStart = i;
+  while (i < end) {
+    if (line[i] === '\\' && i + 1 < end && line[i + 1] === '|') {
+      i += 2;
+      continue;
+    }
+    if (line[i] === '|') {
+      spans.push({ start: cellStart, end: i });
+      cellStart = i + 1;
+    }
+    i++;
+  }
+
+  if (cellStart < end || line[end - 1] !== '|') {
+    spans.push({ start: cellStart, end });
+  }
+
+  return spans;
+}
+
+/** Number of cells on the line. */
+export function cellCount(line: string): number {
+  return cellSpans(line).length;
+}
+
+/**
+ * Insert a cell whose raw text is `text` at `index`. A ragged row shorter than
+ * `index` is grown with copies of `text` rather than having the new cell land
+ * in the wrong column.
+ */
+export function insertCell(line: string, index: number, text: string): string {
+  const spans = cellSpans(line);
+
+  if (index < spans.length) {
+    const at = spans[index].start;
+    // A row without a leading pipe (`a | b`) needs one, or the new first cell
+    // reads as the row's opening delimiter and its content is lost.
+    const opener = index === 0 && !hasLeadingPipe(line) ? '|' : '';
+    return line.slice(0, at) + opener + text + '|' + line.slice(at);
+  }
+
+  if (spans.length === 0) {
+    return line + '|' + text;
+  }
+
+  let out = line;
+  for (let n = spans.length; n < index; n++) {
+    out = appendCell(out, text);
+  }
+  return appendCell(out, text);
+}
+
+/** Grow the line to `count` cells by appending cells of raw text `fill`. */
+export function padCells(line: string, count: number, fill: string): string {
+  let out = line;
+  for (let n = cellCount(out); n < count; n++) {
+    out = appendCell(out, fill);
+  }
+  return out;
+}
+
+function appendCell(line: string, text: string): string {
+  const spans = cellSpans(line);
+  if (spans.length === 0) {
+    return line + '|' + text;
+  }
+  // A row without a trailing pipe (`a | b`) needs one, or an appended blank
+  // cell reads as trailing whitespace and is lost.
+  const closer = hasTrailingPipe(line) ? '' : '|';
+  const at = spans[spans.length - 1].end;
+  return line.slice(0, at) + '|' + text + closer + line.slice(at);
+}
+
+/** Remove the cell at `index`, along with one of its delimiting pipes. */
+export function removeCell(line: string, index: number): string {
+  const spans = cellSpans(line);
+  if (index < 0 || index >= spans.length) {
+    return line;
+  }
+
+  if (spans.length === 1) {
+    return keepIndent(line, line.slice(0, spans[0].start) + line.slice(spans[0].end));
+  }
+
+  if (index === spans.length - 1) {
+    return line.slice(0, spans[index - 1].end) + line.slice(spans[index].end);
+  }
+
+  return keepIndent(
+    line,
+    line.slice(0, spans[index].start) + line.slice(spans[index + 1].start)
+  );
+}
+
+/** Swap the raw text (padding included) of two cells. */
+export function swapCells(line: string, a: number, b: number): string {
+  if (a === b) {
+    return line;
+  }
+  const spans = cellSpans(line);
+  const low = Math.min(a, b);
+  const high = Math.max(a, b);
+  if (low < 0 || high >= spans.length) {
+    return line;
+  }
+
+  const first = spans[low];
+  const second = spans[high];
+  return keepIndent(
+    line,
+    line.slice(0, first.start) +
+      line.slice(second.start, second.end) +
+      line.slice(first.end, second.start) +
+      line.slice(first.start, first.end) +
+      line.slice(second.end)
+  );
+}
+
+/**
+ * Re-anchor a transformed line to the source's indent. On a row without a
+ * leading pipe the first cell's span starts at the indent, so moving another
+ * cell's padding into that slot would silently re-indent the whole table.
+ */
+function keepIndent(source: string, result: string): string {
+  return source.slice(0, firstNonSpace(source)) + result.slice(firstNonSpace(result));
+}
+
+function hasLeadingPipe(line: string): boolean {
+  return line[firstNonSpace(line)] === '|';
+}
+
+function hasTrailingPipe(line: string): boolean {
+  const end = lastNonSpaceEnd(line);
+  return end > firstNonSpace(line) && line[end - 1] === '|';
+}
+
+/**
+ * Clone a row's pipe structure with every cell blanked, keeping each cell's
+ * rendered width so the new row's pipes line up with the row it was cloned
+ * from — however that row happens to be padded.
+ */
+export function blankRowLike(line: string): string {
+  const spans = cellSpans(line);
+  if (spans.length === 0) {
+    return line;
+  }
+
+  let out = '';
+  let cursor = 0;
+  for (const span of spans) {
+    out += line.slice(cursor, span.start);
+    out += ' '.repeat(visualWidth(line.slice(span.start, span.end)));
+    cursor = span.end;
+  }
+  return out + line.slice(cursor);
+}
+
+function firstNonSpace(line: string): number {
+  let i = 0;
+  while (i < line.length && /\s/.test(line[i])) {
+    i++;
+  }
+  return i;
+}
+
+function lastNonSpaceEnd(line: string): number {
+  let i = line.length;
+  while (i > 0 && /\s/.test(line[i - 1])) {
+    i--;
+  }
+  return i;
+}

--- a/src/table/commands/navigate.ts
+++ b/src/table/commands/navigate.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { locateTable, cursorToTableCoords, TableLocation } from '../locator';
-import { blankRowLike, cellCount } from '../cells';
+import { blankRowLike, cellCount, padCells } from '../cells';
 import { documentEol, readTableLines, renderTableLines } from './tableEdit';
 
 /**
@@ -43,15 +43,17 @@ function bodyRowCount(lines: string[]): number {
 }
 
 /**
- * Append a row shaped like the table's last line, so its pipes line up with
- * the table as it already is when `alignOnEdit` is off.
+ * Append a row shaped like the table's last line — but never narrower than
+ * the header — so its pipes line up with the table as it already is when
+ * `alignOnEdit` is off, and every column can still be tabbed into.
  */
 async function appendBlankRow(
   editor: vscode.TextEditor,
   location: TableLocation,
   lines: string[]
 ): Promise<void> {
-  const next = [...lines, blankRowLike(lines[lines.length - 1])];
+  const reference = padCells(lines[lines.length - 1], cellCount(lines[0]), '  ');
+  const next = [...lines, blankRowLike(reference)];
   const text = renderTableLines(next, location, documentEol(editor.document));
   await editor.edit((edit) => edit.replace(location.range, text));
 }

--- a/src/table/commands/navigate.ts
+++ b/src/table/commands/navigate.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
-import { locateTable, cursorToTableCoords } from '../locator';
-import { parseTable } from '../parser';
-import { formatTable } from '../formatter';
+import { locateTable, cursorToTableCoords, TableLocation } from '../locator';
+import { blankRowLike, cellCount } from '../cells';
+import { documentEol, readTableLines, renderTableLines } from './tableEdit';
 
 /**
  * Move cursor to the next cell.
@@ -18,8 +18,8 @@ export async function nextCellCommand(): Promise<void> {
   const coords = cursorToTableCoords(document, location, editor.selection.active);
   if (!coords) {return;}
 
-  const model = parseTable(document, location);
-  const columnCount = model.headers.length;
+  const lines = readTableLines(document, location);
+  const columnCount = cellCount(lines[0]);
 
   let targetRow = coords.rowIndex;
   let targetCol = coords.columnIndex + 1;
@@ -28,17 +28,32 @@ export async function nextCellCommand(): Promise<void> {
     targetCol = 0;
     targetRow = targetRow + 1;
 
-    if (targetRow >= model.rows.length) {
-      const newRow = Array(columnCount).fill('');
-      model.rows.push(newRow);
-      const formatted = formatTable(model);
-      await editor.edit((edit) => edit.replace(location.range, formatted));
+    if (targetRow >= bodyRowCount(lines)) {
+      await appendBlankRow(editor, location, lines);
       await moveCursorToCell(location.headerLine, targetRow, targetCol);
       return;
     }
   }
 
   await moveCursorToCell(location.headerLine, targetRow, targetCol);
+}
+
+function bodyRowCount(lines: string[]): number {
+  return lines.length - 2;
+}
+
+/**
+ * Append a row shaped like the table's last line, so its pipes line up with
+ * the table as it already is when `alignOnEdit` is off.
+ */
+async function appendBlankRow(
+  editor: vscode.TextEditor,
+  location: TableLocation,
+  lines: string[]
+): Promise<void> {
+  const next = [...lines, blankRowLike(lines[lines.length - 1])];
+  const text = renderTableLines(next, location, documentEol(editor.document));
+  await editor.edit((edit) => edit.replace(location.range, text));
 }
 
 export async function previousCellCommand(): Promise<void> {
@@ -52,13 +67,13 @@ export async function previousCellCommand(): Promise<void> {
   const coords = cursorToTableCoords(document, location, editor.selection.active);
   if (!coords) {return;}
 
-  const model = parseTable(document, location);
+  const lines = readTableLines(document, location);
 
   let targetRow = coords.rowIndex;
   let targetCol = coords.columnIndex - 1;
 
   if (targetCol < 0) {
-    targetCol = model.headers.length - 1;
+    targetCol = cellCount(lines[0]) - 1;
     targetRow = targetRow - 1;
     if (targetRow < -1) {return;}
   }
@@ -81,15 +96,11 @@ export async function nextRowCommand(): Promise<void> {
   const coords = cursorToTableCoords(document, location, editor.selection.active);
   if (!coords) {return;}
 
-  const model = parseTable(document, location);
-  const columnCount = model.headers.length;
+  const lines = readTableLines(document, location);
   const targetRow = coords.rowIndex + 1;
 
-  if (targetRow >= model.rows.length) {
-    const newRow = Array(columnCount).fill('');
-    model.rows.push(newRow);
-    const formatted = formatTable(model);
-    await editor.edit((edit) => edit.replace(location.range, formatted));
+  if (targetRow >= bodyRowCount(lines)) {
+    await appendBlankRow(editor, location, lines);
   }
 
   await moveCursorToCell(location.headerLine, targetRow, 0);

--- a/src/table/commands/rowColumn.ts
+++ b/src/table/commands/rowColumn.ts
@@ -106,7 +106,7 @@ export async function insertRowAboveCommand(): Promise<void> {
   await transformTable((lines, { rowIndex, columnIndex }) => {
     const insertAt = Math.max(0, rowIndex); // header row treated as index 0
     const next = [...lines];
-    next.splice(insertAt + 2, 0, blankRowLike(lines[lineOf(rowIndex)]));
+    next.splice(insertAt + 2, 0, blankRowFrom(lines, rowIndex));
     return { lines: next, cursor: { rowIndex: insertAt, columnIndex } };
   });
 }
@@ -115,9 +115,19 @@ export async function insertRowBelowCommand(): Promise<void> {
   await transformTable((lines, { rowIndex, columnIndex }) => {
     const insertAt = rowIndex < 0 ? 0 : rowIndex + 1;
     const next = [...lines];
-    next.splice(insertAt + 2, 0, blankRowLike(lines[lineOf(rowIndex)]));
+    next.splice(insertAt + 2, 0, blankRowFrom(lines, rowIndex));
     return { lines: next, cursor: { rowIndex: insertAt, columnIndex } };
   });
+}
+
+/**
+ * A blank row shaped like the cursor's row, but never narrower than the
+ * header — a ragged neighbor must not hand the new row too few cells to put
+ * the cursor in.
+ */
+function blankRowFrom(lines: string[], rowIndex: number): string {
+  const reference = lines[lineOf(rowIndex)];
+  return blankRowLike(padCells(reference, cellCount(lines[0]), EMPTY_CELL));
 }
 
 export async function insertColumnLeftCommand(): Promise<void> {
@@ -177,7 +187,7 @@ export async function deleteColumnCommand(): Promise<void> {
     // A cursor in a body row wider than the header can point past the last
     // column; there is nothing there to delete.
     if (columnIndex >= columns) {
-      return { lines, cursor: { rowIndex, columnIndex: columns - 1 } };
+      return null;
     }
     return {
       lines: lines.map((line) => removeCell(line, columnIndex)),

--- a/src/table/commands/rowColumn.ts
+++ b/src/table/commands/rowColumn.ts
@@ -1,21 +1,27 @@
 import * as vscode from 'vscode';
 import { locateTable, cursorToTableCoords } from '../locator';
-import { parseTable } from '../parser';
-import { formatTable } from '../formatter';
+import { blankRowLike, cellCount, insertCell, padCells, removeCell, swapCells } from '../cells';
 import { computeCellRange } from './navigate';
-import { Alignment, TableCursor, TableModel } from '../types';
+import { documentEol, readTableLines, renderTableLines } from './tableEdit';
+import { Alignment, TableCursor } from '../types';
+
+/** Index of the separator row within a table's raw lines. */
+const SEPARATOR = 1;
+/** Raw text of an empty cell: `|  |`. */
+const EMPTY_CELL = '  ';
 
 /**
- * Shared helper: load the table at the cursor, run a transform on the model,
- * then write it back. If the transform returns a cursor, the selection is
- * repositioned to a collapsed caret at that cell's content start so repeated
- * invocations keep operating on the same (moved) content.
+ * Shared helper: load the raw lines of the table at the cursor, run a line
+ * transform, then write them back — aligned or verbatim, per `alignOnEdit`.
+ * If the transform returns a cursor, the selection is repositioned to a
+ * collapsed caret at that cell's content start so repeated invocations keep
+ * operating on the same (moved) content.
  */
 async function transformTable(
   transform: (
-    model: TableModel,
+    lines: string[],
     coords: TableCursor
-  ) => { model: TableModel; cursor?: TableCursor } | null
+  ) => { lines: string[]; cursor?: TableCursor } | null
 ): Promise<void> {
   const editor = vscode.window.activeTextEditor;
   if (!editor) {return;}
@@ -34,13 +40,12 @@ async function transformTable(
     return;
   }
 
-  const model = parseTable(document, location);
-  const result = transform(model, coords);
+  const result = transform(readTableLines(document, location), coords);
   if (!result) {return;}
 
-  const formatted = formatTable(result.model);
+  const text = renderTableLines(result.lines, location, documentEol(document));
   const applied = await editor.edit((edit) => {
-    edit.replace(location.range, formatted);
+    edit.replace(location.range, text);
   });
 
   if (applied && result.cursor) {
@@ -72,138 +77,149 @@ function defaultAlignment(): Alignment {
   return (config.get<Alignment>('defaultAlignment') ?? 'left');
 }
 
+/** Raw text of a separator cell carrying the given alignment. */
+function separatorCell(alignment: Alignment): string {
+  switch (alignment) {
+    case 'left':
+      return ' :--- ';
+    case 'right':
+      return ' ---: ';
+    case 'center':
+      return ' :---: ';
+    case 'none':
+    default:
+      return ' --- ';
+  }
+}
+
+/** Fill text used to grow a ragged row so `index` lands in the right column. */
+function fillFor(lineIndex: number): string {
+  return lineIndex === SEPARATOR ? separatorCell('none') : EMPTY_CELL;
+}
+
+/** Line index of a table row: -1 is the header, 0+ are body rows. */
+function lineOf(rowIndex: number): number {
+  return rowIndex === -1 ? 0 : rowIndex + 2;
+}
+
 export async function insertRowAboveCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
-    const newRow = Array(model.headers.length).fill('');
+  await transformTable((lines, { rowIndex, columnIndex }) => {
     const insertAt = Math.max(0, rowIndex); // header row treated as index 0
-    const rows = [...model.rows];
-    rows.splice(insertAt, 0, newRow);
-    return { model: { ...model, rows }, cursor: { rowIndex: insertAt, columnIndex } };
+    const next = [...lines];
+    next.splice(insertAt + 2, 0, blankRowLike(lines[lineOf(rowIndex)]));
+    return { lines: next, cursor: { rowIndex: insertAt, columnIndex } };
   });
 }
 
 export async function insertRowBelowCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
-    const newRow = Array(model.headers.length).fill('');
+  await transformTable((lines, { rowIndex, columnIndex }) => {
     const insertAt = rowIndex < 0 ? 0 : rowIndex + 1;
-    const rows = [...model.rows];
-    rows.splice(insertAt, 0, newRow);
-    return { model: { ...model, rows }, cursor: { rowIndex: insertAt, columnIndex } };
+    const next = [...lines];
+    next.splice(insertAt + 2, 0, blankRowLike(lines[lineOf(rowIndex)]));
+    return { lines: next, cursor: { rowIndex: insertAt, columnIndex } };
   });
 }
 
 export async function insertColumnLeftCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
-    return { model: insertColumnAt(model, columnIndex), cursor: { rowIndex, columnIndex } };
+  await transformTable((lines, { rowIndex, columnIndex }) => {
+    return { lines: insertColumnAt(lines, columnIndex), cursor: { rowIndex, columnIndex } };
   });
 }
 
 export async function insertColumnRightCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
+  await transformTable((lines, { rowIndex, columnIndex }) => {
     return {
-      model: insertColumnAt(model, columnIndex + 1),
+      lines: insertColumnAt(lines, columnIndex + 1),
       cursor: { rowIndex, columnIndex: columnIndex + 1 }
     };
   });
 }
 
-function insertColumnAt(model: TableModel, index: number): TableModel {
-  const align = defaultAlignment();
-  const headers = [...model.headers];
-  const alignments = [...model.alignments];
-  headers.splice(index, 0, '');
-  alignments.splice(index, 0, align);
-  const rows = model.rows.map((row) => {
-    const r = [...row];
-    r.splice(index, 0, '');
-    return r;
+function insertColumnAt(lines: string[], index: number): string[] {
+  const newCell = separatorCell(defaultAlignment());
+  const columns = cellCount(lines[0]);
+  return lines.map((line, i) => {
+    const cell = i === SEPARATOR ? newCell : EMPTY_CELL;
+    return insertCell(padCells(line, columns, fillFor(i)), index, cell);
   });
-  return { ...model, headers, alignments, rows };
 }
 
 export async function deleteRowCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
+  await transformTable((lines, { rowIndex, columnIndex }) => {
     if (rowIndex < 0) {
       vscode.window.showInformationMessage('Markdown Foundry: cannot delete the header row.');
       return null;
     }
-    if (model.rows.length === 0) {return null;}
-    const rows = [...model.rows];
-    rows.splice(rowIndex, 1);
-    const cursorRow = rows.length === 0 ? -1 : Math.min(rowIndex, rows.length - 1);
-    return { model: { ...model, rows }, cursor: { rowIndex: cursorRow, columnIndex } };
+    if (lines.length <= 2) {return null;}
+    const next = [...lines];
+    next.splice(rowIndex + 2, 1);
+    const remaining = next.length - 2;
+    const cursorRow = remaining === 0 ? -1 : Math.min(rowIndex, remaining - 1);
+    return { lines: next, cursor: { rowIndex: cursorRow, columnIndex } };
   });
 }
 
 export async function deleteColumnCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
-    if (model.headers.length <= 1) {
+  await transformTable((lines, { rowIndex, columnIndex }) => {
+    const columns = cellCount(lines[0]);
+    if (columns <= 1) {
       vscode.window.showInformationMessage('Markdown Foundry: cannot delete the last column.');
       return null;
     }
-    const headers = [...model.headers];
-    const alignments = [...model.alignments];
-    headers.splice(columnIndex, 1);
-    alignments.splice(columnIndex, 1);
-    const rows = model.rows.map((row) => {
-      const r = [...row];
-      r.splice(columnIndex, 1);
-      return r;
-    });
     return {
-      model: { ...model, headers, alignments, rows },
-      cursor: { rowIndex, columnIndex: Math.min(columnIndex, headers.length - 1) }
+      lines: lines.map((line) => removeCell(line, columnIndex)),
+      cursor: { rowIndex, columnIndex: Math.min(columnIndex, columns - 2) }
     };
   });
 }
 
 export async function moveRowUpCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
+  await transformTable((lines, { rowIndex, columnIndex }) => {
     if (rowIndex <= 0) {return null;}
-    const rows = [...model.rows];
-    [rows[rowIndex - 1], rows[rowIndex]] = [rows[rowIndex], rows[rowIndex - 1]];
-    return { model: { ...model, rows }, cursor: { rowIndex: rowIndex - 1, columnIndex } };
+    return {
+      lines: swapLines(lines, rowIndex + 2, rowIndex + 1),
+      cursor: { rowIndex: rowIndex - 1, columnIndex }
+    };
   });
 }
 
 export async function moveRowDownCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
-    if (rowIndex < 0 || rowIndex >= model.rows.length - 1) {return null;}
-    const rows = [...model.rows];
-    [rows[rowIndex + 1], rows[rowIndex]] = [rows[rowIndex], rows[rowIndex + 1]];
-    return { model: { ...model, rows }, cursor: { rowIndex: rowIndex + 1, columnIndex } };
+  await transformTable((lines, { rowIndex, columnIndex }) => {
+    if (rowIndex < 0 || rowIndex >= lines.length - 3) {return null;}
+    return {
+      lines: swapLines(lines, rowIndex + 2, rowIndex + 3),
+      cursor: { rowIndex: rowIndex + 1, columnIndex }
+    };
   });
 }
 
+function swapLines(lines: string[], a: number, b: number): string[] {
+  const next = [...lines];
+  [next[a], next[b]] = [next[b], next[a]];
+  return next;
+}
+
 export async function moveColumnLeftCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
+  await transformTable((lines, { rowIndex, columnIndex }) => {
     if (columnIndex <= 0) {return null;}
     return {
-      model: swapColumns(model, columnIndex, columnIndex - 1),
+      lines: swapColumns(lines, columnIndex, columnIndex - 1),
       cursor: { rowIndex, columnIndex: columnIndex - 1 }
     };
   });
 }
 
 export async function moveColumnRightCommand(): Promise<void> {
-  await transformTable((model, { rowIndex, columnIndex }) => {
-    if (columnIndex >= model.headers.length - 1) {return null;}
+  await transformTable((lines, { rowIndex, columnIndex }) => {
+    if (columnIndex >= cellCount(lines[0]) - 1) {return null;}
     return {
-      model: swapColumns(model, columnIndex, columnIndex + 1),
+      lines: swapColumns(lines, columnIndex, columnIndex + 1),
       cursor: { rowIndex, columnIndex: columnIndex + 1 }
     };
   });
 }
 
-function swapColumns(model: TableModel, a: number, b: number): TableModel {
-  const headers = [...model.headers];
-  const alignments = [...model.alignments];
-  [headers[a], headers[b]] = [headers[b], headers[a]];
-  [alignments[a], alignments[b]] = [alignments[b], alignments[a]];
-  const rows = model.rows.map((row) => {
-    const r = [...row];
-    [r[a], r[b]] = [r[b], r[a]];
-    return r;
-  });
-  return { ...model, headers, alignments, rows };
+function swapColumns(lines: string[], a: number, b: number): string[] {
+  const columns = cellCount(lines[0]);
+  return lines.map((line, i) => swapCells(padCells(line, columns, fillFor(i)), a, b));
 }

--- a/src/table/commands/rowColumn.ts
+++ b/src/table/commands/rowColumn.ts
@@ -122,17 +122,25 @@ export async function insertRowBelowCommand(): Promise<void> {
 
 export async function insertColumnLeftCommand(): Promise<void> {
   await transformTable((lines, { rowIndex, columnIndex }) => {
-    return { lines: insertColumnAt(lines, columnIndex), cursor: { rowIndex, columnIndex } };
+    const index = columnOf(lines, columnIndex);
+    return { lines: insertColumnAt(lines, index), cursor: { rowIndex, columnIndex: index } };
   });
 }
 
 export async function insertColumnRightCommand(): Promise<void> {
   await transformTable((lines, { rowIndex, columnIndex }) => {
-    return {
-      lines: insertColumnAt(lines, columnIndex + 1),
-      cursor: { rowIndex, columnIndex: columnIndex + 1 }
-    };
+    const index = columnOf(lines, columnIndex + 1);
+    return { lines: insertColumnAt(lines, index), cursor: { rowIndex, columnIndex: index } };
   });
+}
+
+/**
+ * A body row wider than the header lets the cursor report a column past the
+ * header's last one. Clamping keeps the new column inside the table, the way
+ * Array.splice clamps a past-the-end index.
+ */
+function columnOf(lines: string[], index: number): number {
+  return Math.min(index, cellCount(lines[0]));
 }
 
 function insertColumnAt(lines: string[], index: number): string[] {
@@ -165,6 +173,11 @@ export async function deleteColumnCommand(): Promise<void> {
     if (columns <= 1) {
       vscode.window.showInformationMessage('Markdown Foundry: cannot delete the last column.');
       return null;
+    }
+    // A cursor in a body row wider than the header can point past the last
+    // column; there is nothing there to delete.
+    if (columnIndex >= columns) {
+      return { lines, cursor: { rowIndex, columnIndex: columns - 1 } };
     }
     return {
       lines: lines.map((line) => removeCell(line, columnIndex)),
@@ -201,7 +214,7 @@ function swapLines(lines: string[], a: number, b: number): string[] {
 
 export async function moveColumnLeftCommand(): Promise<void> {
   await transformTable((lines, { rowIndex, columnIndex }) => {
-    if (columnIndex <= 0) {return null;}
+    if (columnIndex <= 0 || columnIndex >= cellCount(lines[0])) {return null;}
     return {
       lines: swapColumns(lines, columnIndex, columnIndex - 1),
       cursor: { rowIndex, columnIndex: columnIndex - 1 }

--- a/src/table/commands/sort.ts
+++ b/src/table/commands/sort.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { locateTable, cursorToTableCoords } from '../locator';
-import { parseTable } from '../parser';
-import { formatTable } from '../formatter';
+import { splitRow } from '../parser';
+import { documentEol, readTableLines, renderTableLines } from './tableEdit';
 
 /**
  * Sort the table rows by the column containing the cursor.
@@ -35,31 +35,41 @@ export async function sortByColumnCommand(): Promise<void> {
   );
   if (!direction) {return;}
 
-  const model = parseTable(document, location);
-  const col = coords.columnIndex;
+  const lines = readTableLines(document, location);
+  const sorted = [
+    ...lines.slice(0, 2),
+    ...sortRowLines(lines.slice(2), coords.columnIndex, direction.value === 'desc')
+  ];
 
-  const isNumeric = model.rows.every((row) => {
-    const value = (row[col] ?? '').trim();
+  const text = renderTableLines(sorted, location, documentEol(document));
+  await editor.edit((edit) => edit.replace(location.range, text));
+}
+
+/** Reorder body rows verbatim, comparing the cell values of one column. */
+export function sortRowLines(
+  rows: string[],
+  columnIndex: number,
+  descending: boolean
+): string[] {
+  const valueOf = (line: string): string => (splitRow(line)[columnIndex] ?? '').trim();
+
+  const isNumeric = rows.every((line) => {
+    const value = valueOf(line);
     if (value === '') {return true;}
     return !isNaN(Number(value));
   });
 
-  const sorted = [...model.rows].sort((a, b) => {
-    const av = (a[col] ?? '').trim();
-    const bv = (b[col] ?? '').trim();
+  const sorted = [...rows].sort((a, b) => {
+    const av = valueOf(a);
+    const bv = valueOf(b);
     if (isNumeric) {
-      const an = Number(av);
-      const bn = Number(bv);
-      return an - bn;
+      return Number(av) - Number(bv);
     }
     return av.localeCompare(bv, undefined, { sensitivity: 'base' });
   });
 
-  if (direction.value === 'desc') {
+  if (descending) {
     sorted.reverse();
   }
-
-  const newModel = { ...model, rows: sorted };
-  const formatted = formatTable(newModel);
-  await editor.edit((edit) => edit.replace(location.range, formatted));
+  return sorted;
 }

--- a/src/table/commands/sort.ts
+++ b/src/table/commands/sort.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { locateTable, cursorToTableCoords } from '../locator';
 import { splitRow } from '../parser';
+import { cellCount } from '../cells';
 import { documentEol, readTableLines, renderTableLines } from './tableEdit';
 
 /**
@@ -38,20 +39,31 @@ export async function sortByColumnCommand(): Promise<void> {
   const lines = readTableLines(document, location);
   const sorted = [
     ...lines.slice(0, 2),
-    ...sortRowLines(lines.slice(2), coords.columnIndex, direction.value === 'desc')
+    ...sortRowLines(
+      lines.slice(2),
+      coords.columnIndex,
+      direction.value === 'desc',
+      cellCount(lines[0])
+    )
   ];
 
   const text = renderTableLines(sorted, location, documentEol(document));
   await editor.edit((edit) => edit.replace(location.range, text));
 }
 
-/** Reorder body rows verbatim, comparing the cell values of one column. */
+/**
+ * Reorder body rows verbatim, comparing the cell values of one column.
+ * Cells past the header's last column are not part of the table, so they
+ * compare as empty — a row wider than the header cannot skew the sort.
+ */
 export function sortRowLines(
   rows: string[],
   columnIndex: number,
-  descending: boolean
+  descending: boolean,
+  columnCount: number
 ): string[] {
-  const valueOf = (line: string): string => (splitRow(line)[columnIndex] ?? '').trim();
+  const valueOf = (line: string): string =>
+    columnIndex >= columnCount ? '' : (splitRow(line)[columnIndex] ?? '').trim();
 
   const isNumeric = rows.every((line) => {
     const value = valueOf(line);

--- a/src/table/commands/tableEdit.ts
+++ b/src/table/commands/tableEdit.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+import { TableLocation } from '../locator';
+import { parseTableFromLines } from '../parser';
+import { formatTable } from '../formatter';
+
+/** Raw source lines of a located table: header, separator, then body rows. */
+export function readTableLines(
+  document: vscode.TextDocument,
+  location: TableLocation
+): string[] {
+  const lines: string[] = [];
+  for (let i = location.headerLine; i <= location.lastBodyLine; i++) {
+    lines.push(document.lineAt(i).text);
+  }
+  return lines;
+}
+
+export function documentEol(document: vscode.TextDocument): string {
+  return document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
+}
+
+function alignOnEdit(): boolean {
+  return vscode.workspace.getConfiguration('markdownFoundry').get<boolean>('alignOnEdit') ?? false;
+}
+
+/**
+ * Render edited table lines back to document text. Editing commands rewrite
+ * the raw lines so untouched cells keep their padding; aligning the result is
+ * an opt-in post-pass, which is what makes both modes share one code path.
+ */
+export function renderTableLines(
+  lines: string[],
+  location: TableLocation,
+  eol: string
+): string {
+  if (!alignOnEdit()) {
+    return lines.join(eol);
+  }
+  return formatTable(parseTableFromLines(lines, location.range, eol));
+}

--- a/src/table/parser.ts
+++ b/src/table/parser.ts
@@ -15,27 +15,34 @@ export function parseTable(
   document: vscode.TextDocument,
   location: TableLocation
 ): TableModel {
-  const headerText = document.lineAt(location.headerLine).text;
-  const separatorText = document.lineAt(location.separatorLine).text;
+  const lines: string[] = [];
+  for (let i = location.headerLine; i <= location.lastBodyLine; i++) {
+    lines.push(document.lineAt(i).text);
+  }
+  const eol = document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
+  return parseTableFromLines(lines, location.range, eol);
+}
+
+/**
+ * Parse raw table lines — header, separator, then body rows — into a
+ * TableModel. Lets edited lines be re-parsed without a TextDocument.
+ */
+export function parseTableFromLines(
+  lines: string[],
+  range: vscode.Range,
+  eol: string
+): TableModel {
+  const headerText = lines[0] ?? '';
+  const separatorText = lines[1] ?? '';
 
   const indent = leadingIndent(headerText);
   const headers = splitRow(headerText);
   const alignments = parseAlignments(separatorText, headers.length);
+  const rows = lines
+    .slice(2)
+    .map((line) => normalizeRowWidth(splitRow(line), headers.length));
 
-  const rows: string[][] = [];
-  for (let i = location.separatorLine + 1; i <= location.lastBodyLine; i++) {
-    const row = splitRow(document.lineAt(i).text);
-    rows.push(normalizeRowWidth(row, headers.length));
-  }
-
-  return {
-    headers,
-    alignments,
-    rows,
-    range: location.range,
-    indent,
-    eol: document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n'
-  };
+  return { headers, alignments, rows, range, indent, eol };
 }
 
 function leadingIndent(text: string): string {

--- a/src/test/suite/cells.test.ts
+++ b/src/test/suite/cells.test.ts
@@ -1,0 +1,181 @@
+import * as assert from 'assert';
+import {
+  blankRowLike,
+  cellCount,
+  cellSpans,
+  insertCell,
+  padCells,
+  removeCell,
+  swapCells
+} from '../../table/cells';
+
+function texts(line: string): string[] {
+  return cellSpans(line).map((span) => line.slice(span.start, span.end));
+}
+
+suite('cells: cellSpans', () => {
+  test('spans cover each cell pipe-to-pipe, padding included', () => {
+    assert.deepStrictEqual(cellSpans('| a | b |'), [
+      { start: 1, end: 4 },
+      { start: 5, end: 8 }
+    ]);
+    assert.deepStrictEqual(texts('| a | b |'), [' a ', ' b ']);
+  });
+
+  test('escaped pipes are content, not separators', () => {
+    assert.deepStrictEqual(texts('| a \\| b | c |'), [' a \\| b ', ' c ']);
+    assert.strictEqual(cellCount('| a \\| b | c |'), 2);
+  });
+
+  test('leading indent stays outside the first cell', () => {
+    assert.deepStrictEqual(cellSpans('  | a | b |'), [
+      { start: 3, end: 6 },
+      { start: 7, end: 10 }
+    ]);
+  });
+
+  test('rows without leading or trailing pipes', () => {
+    assert.deepStrictEqual(texts('a | b'), ['a ', ' b']);
+    assert.deepStrictEqual(texts('| a | b'), [' a ', ' b']);
+    assert.deepStrictEqual(texts('a | b |'), ['a ', ' b ']);
+  });
+
+  test('trailing whitespace after the closing pipe is not a cell', () => {
+    assert.strictEqual(cellCount('| a | b |   '), 2);
+  });
+
+  test('empty and whitespace-only cells are still cells', () => {
+    assert.deepStrictEqual(texts('|  |  |'), ['  ', '  ']);
+    assert.deepStrictEqual(texts('|||'), ['', '']);
+  });
+
+  test('single-column rows', () => {
+    assert.deepStrictEqual(texts('| a |'), [' a ']);
+    assert.strictEqual(cellCount('| a |'), 1);
+  });
+});
+
+suite('cells: insertCell', () => {
+  test('inserts before the cell at the index, leaving other cells byte-identical', () => {
+    assert.strictEqual(insertCell('| Name | Age |', 1, '  '), '| Name |  | Age |');
+    assert.strictEqual(insertCell('| Name | Age |', 0, '  '), '|  | Name | Age |');
+  });
+
+  test('appends when the index is the cell count', () => {
+    assert.strictEqual(insertCell('| a | b |', 2, '  '), '| a | b |  |');
+  });
+
+  test('keeps the indent of an indented row', () => {
+    assert.strictEqual(insertCell('  | a | b |', 0, '  '), '  |  | a | b |');
+    assert.strictEqual(insertCell('  | a | b |', 2, ' --- '), '  | a | b | --- |');
+  });
+
+  test('does not split an escaped pipe', () => {
+    assert.strictEqual(insertCell('| a \\| b | c |', 1, '  '), '| a \\| b |  | c |');
+  });
+
+  test('pads a ragged row so the new cell lands in the requested column', () => {
+    assert.strictEqual(insertCell('| a1 |', 3, '  '), '| a1 |  |  |  |');
+    assert.strictEqual(cellCount(insertCell('| a1 |', 3, '  ')), 4);
+  });
+
+  test('a row without a leading pipe gains one, so the new first cell survives', () => {
+    assert.strictEqual(insertCell('a | b', 0, '  '), '|  |a | b');
+    assert.deepStrictEqual(texts('|  |a | b'), ['  ', 'a ', ' b']);
+  });
+
+  test('a row without a trailing pipe gains one, so an appended blank cell survives', () => {
+    assert.strictEqual(insertCell('a | b', 2, '  '), 'a | b|  |');
+    assert.strictEqual(cellCount('a | b|  |'), 3);
+  });
+});
+
+suite('cells: padCells', () => {
+  test('grows a ragged row to the column count', () => {
+    assert.strictEqual(padCells('| a1 |', 3, '  '), '| a1 |  |  |');
+    assert.strictEqual(padCells('| --- |', 3, ' --- '), '| --- | --- | --- |');
+  });
+
+  test('leaves a row that is already wide enough alone', () => {
+    assert.strictEqual(padCells('| a | b | c |', 3, '  '), '| a | b | c |');
+    assert.strictEqual(padCells('| a | b | c |', 2, '  '), '| a | b | c |');
+  });
+});
+
+suite('cells: removeCell', () => {
+  test('removes the cell and one delimiting pipe', () => {
+    assert.strictEqual(removeCell('| a | b | c |', 1), '| a | c |');
+    assert.strictEqual(removeCell('| a | b | c |', 0), '| b | c |');
+    assert.strictEqual(removeCell('| a | b | c |', 2), '| a | b |');
+  });
+
+  test('leaves surviving cells byte-identical, padding included', () => {
+    assert.strictEqual(removeCell('| a |   bbb | c |', 0), '|   bbb | c |');
+  });
+
+  test('does not split an escaped pipe', () => {
+    assert.strictEqual(removeCell('| a \\| x | b |', 1), '| a \\| x |');
+  });
+
+  test('an index past the end of a ragged row is a no-op', () => {
+    assert.strictEqual(removeCell('| a1 |', 2), '| a1 |');
+  });
+
+  test('keeps the indent when the first cell of a pipeless row goes', () => {
+    assert.strictEqual(removeCell('a | b | c', 0), 'b | c');
+    assert.strictEqual(removeCell('  a | b | c', 0), '  b | c');
+  });
+});
+
+suite('cells: swapCells', () => {
+  test('swaps the raw text of two cells', () => {
+    assert.strictEqual(swapCells('| a | bb | c |', 0, 1), '| bb | a | c |');
+    assert.strictEqual(swapCells('| a | bb | c |', 2, 0), '| c | bb | a |');
+  });
+
+  test('argument order does not matter', () => {
+    assert.strictEqual(swapCells('| a | b |', 1, 0), swapCells('| a | b |', 0, 1));
+  });
+
+  test('does not split an escaped pipe', () => {
+    assert.strictEqual(swapCells('| a \\| x | b |', 0, 1), '| b | a \\| x |');
+  });
+
+  test('an index past the end of a ragged row is a no-op', () => {
+    assert.strictEqual(swapCells('| a1 |', 0, 1), '| a1 |');
+  });
+
+  test('keeps the indent of a pipeless row', () => {
+    assert.strictEqual(swapCells('a | b', 0, 1), 'b|a ');
+    assert.strictEqual(swapCells('  a | b', 0, 1), '  b|a ');
+  });
+});
+
+suite('cells: blankRowLike', () => {
+  test('clones the pipe structure with every cell blanked', () => {
+    assert.strictEqual(blankRowLike('| a1 | b1 | c1 |'), '|    |    |    |');
+  });
+
+  test('keeps each cell width so the pipes line up with the source row', () => {
+    assert.strictEqual(blankRowLike('| Alice | 30 |'), '|       |    |');
+  });
+
+  test('keeps the indent', () => {
+    assert.strictEqual(blankRowLike('  | a | bb |'), '  |   |    |');
+  });
+
+  test('uses rendered width, so wide characters still line up', () => {
+    const source = '| 日本語 | 30 |';
+    const blank = blankRowLike(source);
+    assert.strictEqual(blank, '|        |    |');
+    assert.deepStrictEqual(
+      cellSpans(blank).map((s) => s.end - s.start),
+      [8, 4]
+    );
+  });
+
+  test('an escaped pipe does not become a cell boundary', () => {
+    assert.strictEqual(blankRowLike('| a \\| b | c |'), '|        |   |');
+    assert.strictEqual(cellCount(blankRowLike('| a \\| b | c |')), 2);
+  });
+});

--- a/src/test/suite/cells.test.ts
+++ b/src/test/suite/cells.test.ts
@@ -178,4 +178,38 @@ suite('cells: blankRowLike', () => {
     assert.strictEqual(blankRowLike('| a \\| b | c |'), '|        |   |');
     assert.strictEqual(cellCount(blankRowLike('| a \\| b | c |')), 2);
   });
+
+  test('a row missing a leading or trailing pipe gets one, so its cells stay addressable', () => {
+    // Every cell is whitespace now, so the outer pipes are all that delimits
+    // them: 'a | b' blanked to '  |  ' would parse as zero cells.
+    assert.strictEqual(blankRowLike('a | b'), '|  |  |');
+    assert.strictEqual(blankRowLike('| a | b'), '|   |  |');
+    assert.strictEqual(blankRowLike('a | b |'), '|  |   |');
+    assert.strictEqual(blankRowLike('  a | b'), '  |  |  |');
+  });
+
+  test('cell count is invariant under blankRowLike, for every row shape', () => {
+    const shapes = [
+      '| a | b | c |',
+      'a | b',
+      '| a | b',
+      'a | b |',
+      '  | a | b |',
+      '  a | b',
+      '| a \\| x | b |',
+      'a \\| x | b',
+      '| only |',
+      '| a1 |',
+      '|  |  |',
+      '| 日本語 | 30 |',
+      '| --- | --- |'
+    ];
+    for (const shape of shapes) {
+      assert.strictEqual(
+        cellCount(blankRowLike(shape)),
+        cellCount(shape),
+        `cell count changed: [${shape}] -> [${blankRowLike(shape)}]`
+      );
+    }
+  });
 });

--- a/src/test/suite/cells.test.ts
+++ b/src/test/suite/cells.test.ts
@@ -13,6 +13,26 @@ function texts(line: string): string[] {
   return cellSpans(line).map((span) => line.slice(span.start, span.end));
 }
 
+/** Every row shape the primitives have to survive. */
+const SHAPES = [
+  '| a | b | c |',
+  'a | b',
+  '| a | b',
+  'a | b |',
+  '  | a | b |',
+  '  a | b',
+  '| a \\| x | b |',
+  'a \\| x | b',
+  '| a | b \\|',
+  '  | a | b \\|',
+  'a | b \\|',
+  '| only |',
+  '| a1 |',
+  '|  |  |',
+  '| 日本語 | 30 |',
+  '| --- | --- |'
+];
+
 suite('cells: cellSpans', () => {
   test('spans cover each cell pipe-to-pipe, padding included', () => {
     assert.deepStrictEqual(cellSpans('| a | b |'), [
@@ -99,6 +119,22 @@ suite('cells: padCells', () => {
   test('leaves a row that is already wide enough alone', () => {
     assert.strictEqual(padCells('| a | b | c |', 3, '  '), '| a | b | c |');
     assert.strictEqual(padCells('| a | b | c |', 2, '  '), '| a | b | c |');
+  });
+
+  test('grows a row that ends in an escaped pipe', () => {
+    assert.strictEqual(padCells('| a | b \\|', 4, '  '), '| a | b \\||  |  |');
+  });
+
+  test('always reaches the requested width, whatever the row shape', () => {
+    for (const shape of SHAPES) {
+      for (let width = 1; width <= 5; width++) {
+        const padded = padCells(shape, width, '  ');
+        assert.ok(
+          cellCount(padded) >= Math.max(width, cellCount(shape)),
+          `[${shape}] padded to ${width} gave [${padded}] (${cellCount(padded)} cells)`
+        );
+      }
+    }
   });
 });
 
@@ -188,23 +224,15 @@ suite('cells: blankRowLike', () => {
     assert.strictEqual(blankRowLike('  a | b'), '  |  |  |');
   });
 
+  test('a row ending in an escaped pipe is not mistaken for a closed row', () => {
+    // `| a | b \|` has no closing delimiter — its last cell is `b |`.
+    assert.strictEqual(cellCount('| a | b \\|'), 2);
+    assert.strictEqual(blankRowLike('| a | b \\|'), '|   |     |');
+    assert.strictEqual(cellCount(blankRowLike('| a | b \\|')), 2);
+  });
+
   test('cell count is invariant under blankRowLike, for every row shape', () => {
-    const shapes = [
-      '| a | b | c |',
-      'a | b',
-      '| a | b',
-      'a | b |',
-      '  | a | b |',
-      '  a | b',
-      '| a \\| x | b |',
-      'a \\| x | b',
-      '| only |',
-      '| a1 |',
-      '|  |  |',
-      '| 日本語 | 30 |',
-      '| --- | --- |'
-    ];
-    for (const shape of shapes) {
+    for (const shape of SHAPES) {
       assert.strictEqual(
         cellCount(blankRowLike(shape)),
         cellCount(shape),

--- a/src/test/suite/cells.test.ts
+++ b/src/test/suite/cells.test.ts
@@ -30,8 +30,14 @@ const SHAPES = [
   '| a1 |',
   '|  |  |',
   '| 日本語 | 30 |',
-  '| --- | --- |'
+  '| --- | --- |',
+  '|  | x',
+  '||x',
+  '|  | x |'
 ];
+
+/** Mirrors the locator's test for a line that can be part of a table. */
+const UNESCAPED_PIPE = /(?<!\\)\|/;
 
 suite('cells: cellSpans', () => {
   test('spans cover each cell pipe-to-pipe, padding included', () => {
@@ -161,6 +167,44 @@ suite('cells: removeCell', () => {
     assert.strictEqual(removeCell('a | b | c', 0), 'b | c');
     assert.strictEqual(removeCell('  a | b | c', 0), '  b | c');
   });
+
+  test('a surviving blank cell keeps the delimiter that holds it open', () => {
+    // Without the closing pipe, '|  ' is trailing whitespace, not a cell.
+    assert.strictEqual(removeCell('|  | x', 1), '|  |');
+    assert.strictEqual(removeCell('||x', 1), '||');
+  });
+
+  test('the last two columns of a pipeless table keep their pipes', () => {
+    // 'Age' over '---' with no pipes left is not a table — it is a setext H2.
+    assert.strictEqual(removeCell('Name | Age', 0), '| Age|');
+    assert.strictEqual(removeCell('--- | ---', 0), '| ---|');
+    assert.strictEqual(removeCell('Alice | 30', 0), '| 30|');
+  });
+
+  test('removing the only cell leaves an empty, still row-like cell', () => {
+    assert.strictEqual(removeCell('| only |', 0), '||');
+  });
+
+  test('removes one cell and keeps the row row-like, for every row shape', () => {
+    for (const shape of SHAPES) {
+      const count = cellCount(shape);
+      if (count < 2) {
+        continue;
+      }
+      for (let i = 0; i < count; i++) {
+        const result = removeCell(shape, i);
+        assert.strictEqual(
+          cellCount(result),
+          count - 1,
+          `[${shape}] minus cell ${i} gave [${result}]`
+        );
+        assert.ok(
+          UNESCAPED_PIPE.test(result),
+          `[${shape}] minus cell ${i} gave [${result}], which is no longer a table row`
+        );
+      }
+    }
+  });
 });
 
 suite('cells: swapCells', () => {
@@ -184,6 +228,31 @@ suite('cells: swapCells', () => {
   test('keeps the indent of a pipeless row', () => {
     assert.strictEqual(swapCells('a | b', 0, 1), 'b|a ');
     assert.strictEqual(swapCells('  a | b', 0, 1), '  b|a ');
+  });
+
+  test('a blank cell swapped to the end keeps the delimiter that holds it open', () => {
+    assert.strictEqual(swapCells('|  | x', 0, 1), '| x|  |');
+    assert.strictEqual(cellCount(swapCells('|  | x', 0, 1)), 2);
+  });
+
+  test('cell count is invariant under swapCells, for every row shape', () => {
+    for (const shape of SHAPES) {
+      const count = cellCount(shape);
+      for (let a = 0; a < count; a++) {
+        for (let b = 0; b < count; b++) {
+          const result = swapCells(shape, a, b);
+          assert.strictEqual(
+            cellCount(result),
+            count,
+            `[${shape}] swap ${a},${b} gave [${result}]`
+          );
+          assert.ok(
+            UNESCAPED_PIPE.test(result),
+            `[${shape}] swap ${a},${b} gave [${result}], which is no longer a table row`
+          );
+        }
+      }
+    }
   });
 });
 

--- a/src/test/suite/navigate.test.ts
+++ b/src/test/suite/navigate.test.ts
@@ -5,8 +5,12 @@ import {
   nextCellCommand,
   nextRowCommand
 } from '../../table/commands/navigate';
+import { cellCount } from '../../table/cells';
 
 const COMPACT = ['| Name | Age |', '| --- | --- |', '| Alice | 30 |', '| Bob | 7 |'];
+
+/** Valid GFM: rows need no leading or trailing pipes. */
+const PIPELESS = ['a | b', '--- | ---', 'a1 | b1'];
 
 async function openTable(lines: string[]): Promise<vscode.TextEditor> {
   const doc = await vscode.workspace.openTextDocument({
@@ -56,6 +60,33 @@ suite('navigate: the row added past the last cell', () => {
       [...COMPACT, '|     |   |'].join('\n')
     );
     assert.strictEqual(editor.selection.active.line, 4);
+  });
+
+  test('Tab off a pipeless table adds a row whose cells are still addressable', async () => {
+    await setAlignOnEdit(false);
+    const editor = await openTable(PIPELESS);
+    placeCursorInCell(editor, 2, 1);
+    await nextCellCommand();
+    assert.strictEqual(editor.document.getText(), [...PIPELESS, '|   |   |'].join('\n'));
+
+    const added = editor.document.lineAt(3).text;
+    assert.strictEqual(cellCount(added), cellCount(PIPELESS[2]), 'cell count preserved');
+    assert.ok(computeCellRange(added, 0), 'column 0 is navigable');
+    assert.ok(computeCellRange(added, 1), 'column 1 is navigable');
+    assert.strictEqual(editor.selection.active.line, 3);
+  });
+
+  test('Enter on the last row of a pipeless table adds an addressable row', async () => {
+    await setAlignOnEdit(false);
+    const editor = await openTable(PIPELESS);
+    placeCursorInCell(editor, 2, 0);
+    await nextRowCommand();
+    assert.strictEqual(editor.document.getText(), [...PIPELESS, '|   |   |'].join('\n'));
+
+    const added = editor.document.lineAt(3).text;
+    assert.strictEqual(cellCount(added), 2);
+    assert.ok(computeCellRange(added, 1), 'column 1 is navigable');
+    assert.strictEqual(editor.selection.active.line, 3);
   });
 
   test('alignOnEdit re-aligns the table around the added row', async () => {

--- a/src/test/suite/navigate.test.ts
+++ b/src/test/suite/navigate.test.ts
@@ -89,6 +89,19 @@ suite('navigate: the row added past the last cell', () => {
     assert.strictEqual(editor.selection.active.line, 3);
   });
 
+  test('Enter on a ragged last row adds a row as wide as the header', async () => {
+    await setAlignOnEdit(false);
+    const ragged = ['| A | B |', '| --- | --- |', '| a1 |'];
+    const editor = await openTable(ragged);
+    placeCursorInCell(editor, 2, 0);
+    await nextRowCommand();
+    assert.strictEqual(editor.document.getText(), [...ragged, '|    |  |'].join('\n'));
+
+    const added = editor.document.lineAt(3).text;
+    assert.strictEqual(cellCount(added), 2, 'inherits the header width, not the ragged neighbor');
+    assert.ok(computeCellRange(added, 1), 'column 1 is navigable');
+  });
+
   test('alignOnEdit re-aligns the table around the added row', async () => {
     await setAlignOnEdit(true);
     const editor = await openTable(COMPACT);

--- a/src/test/suite/navigate.test.ts
+++ b/src/test/suite/navigate.test.ts
@@ -1,5 +1,80 @@
 import * as assert from 'assert';
-import { computeCellRange } from '../../table/commands/navigate';
+import * as vscode from 'vscode';
+import {
+  computeCellRange,
+  nextCellCommand,
+  nextRowCommand
+} from '../../table/commands/navigate';
+
+const COMPACT = ['| Name | Age |', '| --- | --- |', '| Alice | 30 |', '| Bob | 7 |'];
+
+async function openTable(lines: string[]): Promise<vscode.TextEditor> {
+  const doc = await vscode.workspace.openTextDocument({
+    language: 'markdown',
+    content: lines.join('\n')
+  });
+  return vscode.window.showTextDocument(doc);
+}
+
+async function setAlignOnEdit(value: boolean | undefined): Promise<void> {
+  await vscode.workspace
+    .getConfiguration('markdownFoundry')
+    .update('alignOnEdit', value, vscode.ConfigurationTarget.Global);
+}
+
+function placeCursorInCell(editor: vscode.TextEditor, line: number, columnIndex: number): void {
+  const range = computeCellRange(editor.document.lineAt(line).text, columnIndex);
+  assert.ok(range, `no cell ${columnIndex} on line ${line}`);
+  const pos = new vscode.Position(line, range.start);
+  editor.selection = new vscode.Selection(pos, pos);
+}
+
+suite('navigate: the row added past the last cell', () => {
+  suiteTeardown(async () => {
+    await setAlignOnEdit(undefined);
+  });
+
+  test('Tab off the last cell adds a row shaped like its neighbor', async () => {
+    await setAlignOnEdit(false);
+    const editor = await openTable(COMPACT);
+    placeCursorInCell(editor, 3, 1);
+    await nextCellCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      [...COMPACT, '|     |   |'].join('\n')
+    );
+    assert.strictEqual(editor.selection.active.line, 4);
+  });
+
+  test('Enter on the last row adds a row shaped like its neighbor', async () => {
+    await setAlignOnEdit(false);
+    const editor = await openTable(COMPACT);
+    placeCursorInCell(editor, 3, 0);
+    await nextRowCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      [...COMPACT, '|     |   |'].join('\n')
+    );
+    assert.strictEqual(editor.selection.active.line, 4);
+  });
+
+  test('alignOnEdit re-aligns the table around the added row', async () => {
+    await setAlignOnEdit(true);
+    const editor = await openTable(COMPACT);
+    placeCursorInCell(editor, 3, 1);
+    await nextCellCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      [
+        '| Name  | Age |',
+        '| ----- | --- |',
+        '| Alice | 30  |',
+        '| Bob   | 7   |',
+        '|       |     |'
+      ].join('\n')
+    );
+  });
+});
 
 suite('navigate: computeCellRange', () => {
   test('returns trimmed bounds of a non-empty cell', () => {

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -1,5 +1,68 @@
 import * as assert from 'assert';
-import { splitRow, parseAlignments } from '../../table/parser';
+import * as vscode from 'vscode';
+import { splitRow, parseAlignments, parseTableFromLines } from '../../table/parser';
+
+const RANGE = new vscode.Range(0, 0, 0, 0);
+
+suite('parser: parseTableFromLines', () => {
+  test('parses header, alignments and body rows', () => {
+    const model = parseTableFromLines(
+      ['| A | B |', '| :--- | ---: |', '| a1 | b1 |', '| a2 | b2 |'],
+      RANGE,
+      '\n'
+    );
+    assert.deepStrictEqual(model.headers, ['A', 'B']);
+    assert.deepStrictEqual(model.alignments, ['left', 'right']);
+    assert.deepStrictEqual(model.rows, [
+      ['a1', 'b1'],
+      ['a2', 'b2']
+    ]);
+    assert.strictEqual(model.indent, '');
+    assert.strictEqual(model.eol, '\n');
+  });
+
+  test('pads a ragged row and truncates an over-wide one to the header width', () => {
+    const model = parseTableFromLines(
+      ['| A | B |', '| --- | --- |', '| a1 |', '| a2 | b2 | c2 |'],
+      RANGE,
+      '\n'
+    );
+    assert.deepStrictEqual(model.rows, [
+      ['a1', ''],
+      ['a2', 'b2']
+    ]);
+  });
+
+  test('takes the indent from the header line', () => {
+    const model = parseTableFromLines(
+      ['  | A | B |', '  | --- | --- |', '  | a1 | b1 |'],
+      RANGE,
+      '\n'
+    );
+    assert.strictEqual(model.indent, '  ');
+    assert.deepStrictEqual(model.rows, [['a1', 'b1']]);
+  });
+
+  test('carries the CRLF line ending through to the model', () => {
+    const model = parseTableFromLines(['| A |', '| --- |', '| a1 |'], RANGE, '\r\n');
+    assert.strictEqual(model.eol, '\r\n');
+  });
+
+  test('unescapes pipes in cell values', () => {
+    const model = parseTableFromLines(
+      ['| A | B |', '| --- | --- |', '| a \\| x | b1 |'],
+      RANGE,
+      '\n'
+    );
+    assert.deepStrictEqual(model.rows, [['a | x', 'b1']]);
+  });
+
+  test('a table with no body rows yields no rows', () => {
+    const model = parseTableFromLines(['| A | B |', '| --- | --- |'], RANGE, '\n');
+    assert.deepStrictEqual(model.rows, []);
+    assert.deepStrictEqual(model.headers, ['A', 'B']);
+  });
+});
 
 suite('parser: splitRow', () => {
   test('simple row with leading and trailing pipes', () => {

--- a/src/test/suite/rowColumn.test.ts
+++ b/src/test/suite/rowColumn.test.ts
@@ -32,6 +32,9 @@ const HEADER_NARROW = ['| A | B |', '| --- | --- |', '| a | b | c | d |'];
 /** Valid GFM: rows need no leading or trailing pipes. */
 const PIPELESS = ['a | b', '--- | ---', 'a1 | b1'];
 
+/** A body row with fewer cells than the header. */
+const RAGGED = ['| A | B | C |', '| --- | --- | --- |', '| a1 |'];
+
 async function openTable(content: string = TABLE): Promise<vscode.TextEditor> {
   const doc = await vscode.workspace.openTextDocument({ language: 'markdown', content });
   return vscode.window.showTextDocument(doc);
@@ -295,11 +298,13 @@ suite('rowColumn (alignOnEdit): re-aligns the whole table', () => {
     assertLines(editor, ['| A   | B   |     |', '| --- | --- | :-- |', '| a   | b   |     |']);
   });
 
-  test('delete column from a cell past the header deletes nothing', async () => {
+  // There is no column there to delete, so the command must not touch the
+  // buffer at all — not even to re-align it as a side effect.
+  test('delete column from a cell past the header leaves the buffer untouched', async () => {
     const editor = await openTable(HEADER_NARROW.join('\n'));
     placeCursorInCell(editor, 2, 3);
     await deleteColumnCommand();
-    assertLines(editor, ['| A   | B   |', '| --- | --- |', '| a   | b   |']);
+    assertLines(editor, HEADER_NARROW);
   });
 
   test('move column from a cell past the header is a no-op', async () => {
@@ -484,6 +489,19 @@ suite('rowColumn (preserve): edits leave untouched cells byte-for-byte', () => {
     assert.strictEqual(cellCount(inserted), cellCount(PIPELESS[2]), 'cell count preserved');
     assert.ok(computeCellRange(inserted, 0), 'column 0 is navigable');
     assert.ok(computeCellRange(inserted, 1), 'column 1 is navigable');
+    assertCaretInCell(editor, 3, 0);
+  });
+
+  test('a row inserted next to a ragged row is still as wide as the header', async () => {
+    const editor = await openTable(RAGGED.join('\n'));
+    placeCursorInCell(editor, 2, 0); // the ragged row — it has 1 cell, the header has 3
+    await insertRowBelowCommand();
+    assertLines(editor, [...RAGGED, '|    |  |  |']);
+
+    const inserted = editor.document.lineAt(3).text;
+    assert.strictEqual(cellCount(inserted), 3, 'inherits the header width, not the neighbor');
+    assert.ok(computeCellRange(inserted, 1), 'column 1 is navigable');
+    assert.ok(computeCellRange(inserted, 2), 'column 2 is navigable');
     assertCaretInCell(editor, 3, 0);
   });
 

--- a/src/test/suite/rowColumn.test.ts
+++ b/src/test/suite/rowColumn.test.ts
@@ -22,9 +22,18 @@ const TABLE = [
   '| a3 | b3 | c3 |'
 ].join('\n');
 
+/** Deliberately unpadded — every cell is as narrow as its content. */
+const COMPACT = ['| Name | Age |', '| --- | --- |', '| Alice | 30 |', '| Bob | 7 |'];
+
 async function openTable(content: string = TABLE): Promise<vscode.TextEditor> {
   const doc = await vscode.workspace.openTextDocument({ language: 'markdown', content });
   return vscode.window.showTextDocument(doc);
+}
+
+async function setAlignOnEdit(value: boolean | undefined): Promise<void> {
+  await vscode.workspace
+    .getConfiguration('markdownFoundry')
+    .update('alignOnEdit', value, vscode.ConfigurationTarget.Global);
 }
 
 function placeCursorInCell(editor: vscode.TextEditor, line: number, columnIndex: number): void {
@@ -49,7 +58,21 @@ function assertCaretInCell(editor: vscode.TextEditor, line: number, columnIndex:
   assert.strictEqual(editor.selection.active.character, range.start, 'caret at cell content start');
 }
 
-suite('rowColumn: move commands keep the cursor on the moved content', () => {
+function assertLines(editor: vscode.TextEditor, expected: string[]): void {
+  assert.strictEqual(editor.document.getText(), expected.join('\n'));
+}
+
+// The cursor-following behavior below is mode-independent, so it runs against
+// the aligned default of v0.6.0 (alignOnEdit) as a regression guard.
+suite('rowColumn (alignOnEdit): cursor follows the edit', () => {
+  suiteSetup(async () => {
+    await setAlignOnEdit(true);
+  });
+
+  suiteTeardown(async () => {
+    await setAlignOnEdit(undefined);
+  });
+
   test('move row up follows the moved row, same column', async () => {
     const editor = await openTable();
     placeCursorInCell(editor, 3, 1); // a2 row, column B
@@ -109,9 +132,7 @@ suite('rowColumn: move commands keep the cursor on the moved content', () => {
     assert.strictEqual(cellAt(editor.document, 0, 1), 'C');
     assertCaretInCell(editor, 0, 2);
   });
-});
 
-suite('rowColumn: insert commands place the cursor in the new row/column', () => {
   test('insert row above puts the caret in the inserted row, same column', async () => {
     const editor = await openTable();
     placeCursorInCell(editor, 3, 1); // a2 row, column B
@@ -147,9 +168,7 @@ suite('rowColumn: insert commands place the cursor in the new row/column', () =>
     assert.strictEqual(cellAt(editor.document, 2, 1), 'b1');
     assertCaretInCell(editor, 2, 2);
   });
-});
 
-suite('rowColumn: delete commands clamp the cursor to what remains', () => {
   test('delete middle row keeps the caret at the same row index, same column', async () => {
     const editor = await openTable();
     placeCursorInCell(editor, 3, 1); // a2 row, column B
@@ -183,5 +202,254 @@ suite('rowColumn: delete commands clamp the cursor to what remains', () => {
     assert.strictEqual(cellAt(editor.document, 0, 1), 'B');
     assert.strictEqual(cellAt(editor.document, 3, 1), 'b2');
     assertCaretInCell(editor, 3, 1);
+  });
+});
+
+// v0.6.0 emitted an aligned table after every edit. These pin that output so
+// alignOnEdit stays a faithful opt-in to the old behavior.
+suite('rowColumn (alignOnEdit): re-aligns the whole table', () => {
+  suiteSetup(async () => {
+    await setAlignOnEdit(true);
+  });
+
+  suiteTeardown(async () => {
+    await setAlignOnEdit(undefined);
+  });
+
+  test('insert column right', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 0);
+    await insertColumnRightCommand();
+    assertLines(editor, [
+      '| Name  |     | Age |',
+      '| ----- | :-- | --- |',
+      '| Alice |     | 30  |',
+      '| Bob   |     | 7   |'
+    ]);
+  });
+
+  test('insert row below', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 0);
+    await insertRowBelowCommand();
+    assertLines(editor, [
+      '| Name  | Age |',
+      '| ----- | --- |',
+      '| Alice | 30  |',
+      '|       |     |',
+      '| Bob   | 7   |'
+    ]);
+  });
+
+  test('delete column', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 1);
+    await deleteColumnCommand();
+    assertLines(editor, ['| Name  |', '| ----- |', '| Alice |', '| Bob   |']);
+  });
+
+  test('move column left', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 1);
+    await moveColumnLeftCommand();
+    assertLines(editor, [
+      '| Age | Name  |',
+      '| --- | ----- |',
+      '| 30  | Alice |',
+      '| 7   | Bob   |'
+    ]);
+  });
+
+  test('indented table keeps its indent', async () => {
+    const editor = await openTable(['  | A | B |', '  | --- | --- |', '  | a1 | b1 |'].join('\n'));
+    placeCursorInCell(editor, 2, 0);
+    await insertColumnRightCommand();
+    assertLines(editor, [
+      '  | A   |     | B   |',
+      '  | --- | :-- | --- |',
+      '  | a1  |     | b1  |'
+    ]);
+  });
+});
+
+suite('rowColumn (preserve): edits leave untouched cells byte-for-byte', () => {
+  suiteSetup(async () => {
+    await setAlignOnEdit(false);
+  });
+
+  suiteTeardown(async () => {
+    await setAlignOnEdit(undefined);
+  });
+
+  test('insert column right adds an empty cell and a defaultAlignment marker', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 0);
+    await insertColumnRightCommand();
+    assertLines(editor, [
+      '| Name |  | Age |',
+      '| --- | :--- | --- |',
+      '| Alice |  | 30 |',
+      '| Bob |  | 7 |'
+    ]);
+    assertCaretInCell(editor, 2, 1);
+  });
+
+  test('insert column left adds the cell before the cursor column', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 1);
+    await insertColumnLeftCommand();
+    assertLines(editor, [
+      '| Name |  | Age |',
+      '| --- | :--- | --- |',
+      '| Alice |  | 30 |',
+      '| Bob |  | 7 |'
+    ]);
+    assertCaretInCell(editor, 2, 1);
+  });
+
+  test('insert row below mirrors the neighboring row cell widths', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 1);
+    await insertRowBelowCommand();
+    assertLines(editor, [
+      '| Name | Age |',
+      '| --- | --- |',
+      '| Alice | 30 |',
+      '|       |    |',
+      '| Bob | 7 |'
+    ]);
+    assertCaretInCell(editor, 3, 1);
+  });
+
+  test('insert row above mirrors the neighboring row cell widths', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 3, 0);
+    await insertRowAboveCommand();
+    assertLines(editor, [
+      '| Name | Age |',
+      '| --- | --- |',
+      '| Alice | 30 |',
+      '|     |   |',
+      '| Bob | 7 |'
+    ]);
+    assertCaretInCell(editor, 3, 0);
+  });
+
+  test('delete column removes only that column', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 1);
+    await deleteColumnCommand();
+    assertLines(editor, ['| Name |', '| --- |', '| Alice |', '| Bob |']);
+    assertCaretInCell(editor, 2, 0);
+  });
+
+  test('delete row removes only that line', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 0);
+    await deleteRowCommand();
+    assertLines(editor, ['| Name | Age |', '| --- | --- |', '| Bob | 7 |']);
+    assertCaretInCell(editor, 2, 0);
+  });
+
+  test('move column carries the cell text, not the column padding', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 1);
+    await moveColumnLeftCommand();
+    assertLines(editor, [
+      '| Age | Name |',
+      '| --- | --- |',
+      '| 30 | Alice |',
+      '| 7 | Bob |'
+    ]);
+    assertCaretInCell(editor, 2, 0);
+  });
+
+  test('move row swaps whole lines verbatim', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    placeCursorInCell(editor, 2, 0);
+    await moveRowDownCommand();
+    assertLines(editor, [
+      '| Name | Age |',
+      '| --- | --- |',
+      '| Bob | 7 |',
+      '| Alice | 30 |'
+    ]);
+    assertCaretInCell(editor, 3, 0);
+  });
+
+  test('an already-aligned table stays aligned', async () => {
+    const aligned = [
+      '| A     | B   |',
+      '| :---- | --: |',
+      '| a1    |  b1 |',
+      '| a2    |  b2 |'
+    ];
+    const editor = await openTable(aligned.join('\n'));
+    placeCursorInCell(editor, 2, 0);
+    await moveRowDownCommand();
+    assertLines(editor, [
+      '| A     | B   |',
+      '| :---- | --: |',
+      '| a2    |  b2 |',
+      '| a1    |  b1 |'
+    ]);
+  });
+
+  test('escaped pipes are never treated as cell separators', async () => {
+    const editor = await openTable(
+      ['| A | B |', '| --- | --- |', '| a \\| x | b1 |'].join('\n')
+    );
+    placeCursorInCell(editor, 2, 0);
+    await insertColumnRightCommand();
+    assertLines(editor, [
+      '| A |  | B |',
+      '| --- | :--- | --- |',
+      '| a \\| x |  | b1 |'
+    ]);
+  });
+
+  test('a table indented inside a list item keeps its indent', async () => {
+    const editor = await openTable(
+      ['- item', '  | A | B |', '  | --- | --- |', '  | a1 | b1 |'].join('\n')
+    );
+    placeCursorInCell(editor, 3, 0);
+    await insertColumnRightCommand();
+    assertLines(editor, [
+      '- item',
+      '  | A |  | B |',
+      '  | --- | :--- | --- |',
+      '  | a1 |  | b1 |'
+    ]);
+  });
+
+  test('a ragged row is padded out, not corrupted', async () => {
+    const editor = await openTable(
+      ['| A | B | C |', '| --- | --- | --- |', '| a1 |', '| a2 | b2 | c2 |'].join('\n')
+    );
+    placeCursorInCell(editor, 3, 2);
+    await insertColumnRightCommand();
+    assertLines(editor, [
+      '| A | B | C |  |',
+      '| --- | --- | --- | :--- |',
+      '| a1 |  |  |  |',
+      '| a2 | b2 | c2 |  |'
+    ]);
+  });
+
+  test('a CRLF document keeps its line endings', async () => {
+    const editor = await openTable(COMPACT.join('\n'));
+    await editor.edit((edit) => edit.setEndOfLine(vscode.EndOfLine.CRLF));
+    placeCursorInCell(editor, 2, 0);
+    await insertRowBelowCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      [
+        '| Name | Age |',
+        '| --- | --- |',
+        '| Alice | 30 |',
+        '|       |    |',
+        '| Bob | 7 |'
+      ].join('\r\n')
+    );
   });
 });

--- a/src/test/suite/rowColumn.test.ts
+++ b/src/test/suite/rowColumn.test.ts
@@ -492,6 +492,21 @@ suite('rowColumn (preserve): edits leave untouched cells byte-for-byte', () => {
     assertCaretInCell(editor, 3, 0);
   });
 
+  // Stripping the last pipes would leave `Age` over `---` — a setext heading,
+  // not a table.
+  test('deleting a column from a pipeless table keeps it a table', async () => {
+    const editor = await openTable(['Name | Age', '--- | ---', 'Alice | 30'].join('\n'));
+    placeCursorInCell(editor, 2, 0);
+    await deleteColumnCommand();
+    assertLines(editor, ['| Age|', '| ---|', '| 30|']);
+
+    for (let line = 0; line < 3; line++) {
+      const text = editor.document.lineAt(line).text;
+      assert.ok(/(?<!\\)\|/.test(text), `line ${line} is no longer row-like: [${text}]`);
+      assert.strictEqual(cellCount(text), 1);
+    }
+  });
+
   test('a row inserted next to a ragged row is still as wide as the header', async () => {
     const editor = await openTable(RAGGED.join('\n'));
     placeCursorInCell(editor, 2, 0); // the ragged row — it has 1 cell, the header has 3

--- a/src/test/suite/rowColumn.test.ts
+++ b/src/test/suite/rowColumn.test.ts
@@ -13,6 +13,7 @@ import {
   moveColumnRightCommand
 } from '../../table/commands/rowColumn';
 import { computeCellRange } from '../../table/commands/navigate';
+import { cellCount } from '../../table/cells';
 
 const TABLE = [
   '| A | B | C |',
@@ -24,6 +25,12 @@ const TABLE = [
 
 /** Deliberately unpadded — every cell is as narrow as its content. */
 const COMPACT = ['| Name | Age |', '| --- | --- |', '| Alice | 30 |', '| Bob | 7 |'];
+
+/** A body row wider than the header, so the cursor can sit past its last column. */
+const HEADER_NARROW = ['| A | B |', '| --- | --- |', '| a | b | c | d |'];
+
+/** Valid GFM: rows need no leading or trailing pipes. */
+const PIPELESS = ['a | b', '--- | ---', 'a1 | b1'];
 
 async function openTable(content: string = TABLE): Promise<vscode.TextEditor> {
   const doc = await vscode.workspace.openTextDocument({ language: 'markdown', content });
@@ -270,6 +277,37 @@ suite('rowColumn (alignOnEdit): re-aligns the whole table', () => {
       '  | a1  |     | b1  |'
     ]);
   });
+
+  // The cursor's column is counted on its own line, so a body row wider than
+  // the header reports a column past the header's last. v0.6.0 clamped it via
+  // Array.splice; the new column must not run off the end of the table.
+  test('insert column right from a cell past the header clamps to the last column', async () => {
+    const editor = await openTable(HEADER_NARROW.join('\n'));
+    placeCursorInCell(editor, 2, 3); // the body row's 4th cell — the header has 2
+    await insertColumnRightCommand();
+    assertLines(editor, ['| A   | B   |     |', '| --- | --- | :-- |', '| a   | b   |     |']);
+  });
+
+  test('insert column left from a cell past the header clamps to the last column', async () => {
+    const editor = await openTable(HEADER_NARROW.join('\n'));
+    placeCursorInCell(editor, 2, 2); // the body row's 3rd cell — the header has 2
+    await insertColumnLeftCommand();
+    assertLines(editor, ['| A   | B   |     |', '| --- | --- | :-- |', '| a   | b   |     |']);
+  });
+
+  test('delete column from a cell past the header deletes nothing', async () => {
+    const editor = await openTable(HEADER_NARROW.join('\n'));
+    placeCursorInCell(editor, 2, 3);
+    await deleteColumnCommand();
+    assertLines(editor, ['| A   | B   |', '| --- | --- |', '| a   | b   |']);
+  });
+
+  test('move column from a cell past the header is a no-op', async () => {
+    const editor = await openTable(HEADER_NARROW.join('\n'));
+    placeCursorInCell(editor, 2, 3);
+    await moveColumnLeftCommand();
+    assertLines(editor, HEADER_NARROW);
+  });
 });
 
 suite('rowColumn (preserve): edits leave untouched cells byte-for-byte', () => {
@@ -434,6 +472,26 @@ suite('rowColumn (preserve): edits leave untouched cells byte-for-byte', () => {
       '| a1 |  |  |  |',
       '| a2 | b2 | c2 |  |'
     ]);
+  });
+
+  test('a row inserted into a pipeless table stays addressable', async () => {
+    const editor = await openTable(PIPELESS.join('\n'));
+    placeCursorInCell(editor, 2, 0);
+    await insertRowBelowCommand();
+    assertLines(editor, [...PIPELESS, '|   |   |']);
+
+    const inserted = editor.document.lineAt(3).text;
+    assert.strictEqual(cellCount(inserted), cellCount(PIPELESS[2]), 'cell count preserved');
+    assert.ok(computeCellRange(inserted, 0), 'column 0 is navigable');
+    assert.ok(computeCellRange(inserted, 1), 'column 1 is navigable');
+    assertCaretInCell(editor, 3, 0);
+  });
+
+  test('inserting a column past the header does not destroy the extra cells', async () => {
+    const editor = await openTable(HEADER_NARROW.join('\n'));
+    placeCursorInCell(editor, 2, 3);
+    await insertColumnRightCommand();
+    assertLines(editor, ['| A | B |  |', '| --- | --- | :--- |', '| a | b |  | c | d |']);
   });
 
   test('a CRLF document keeps its line endings', async () => {

--- a/src/test/suite/sort.test.ts
+++ b/src/test/suite/sort.test.ts
@@ -1,7 +1,95 @@
 import * as assert from 'assert';
-import { sortRowLines } from '../../table/commands/sort';
+import * as vscode from 'vscode';
+import { sortByColumnCommand, sortRowLines } from '../../table/commands/sort';
+import { computeCellRange } from '../../table/commands/navigate';
 
 const ROWS = ['| Bob | 7 |', '| Alice | 30 |', '| carol | 8 |'];
+
+const UNSORTED = ['| Name | Age |', '| --- | --- |', '| Bob | 7 |', '| Alice | 30 |'];
+
+/**
+ * Answer the sort command's direction prompt without a UI. The vscode
+ * namespace is not writable through its own types, hence the cast.
+ */
+function stubQuickPick(value: 'asc' | 'desc'): () => void {
+  const win = vscode.window as unknown as { showQuickPick: unknown };
+  const original = win.showQuickPick;
+  win.showQuickPick = (items: unknown): Thenable<unknown> =>
+    Promise.resolve((items as { value: string }[]).find((item) => item.value === value));
+  return () => {
+    win.showQuickPick = original;
+  };
+}
+
+async function setAlignOnEdit(value: boolean | undefined): Promise<void> {
+  await vscode.workspace
+    .getConfiguration('markdownFoundry')
+    .update('alignOnEdit', value, vscode.ConfigurationTarget.Global);
+}
+
+async function openTable(lines: string[]): Promise<vscode.TextEditor> {
+  const doc = await vscode.workspace.openTextDocument({
+    language: 'markdown',
+    content: lines.join('\n')
+  });
+  const editor = await vscode.window.showTextDocument(doc);
+  const range = computeCellRange(doc.lineAt(2).text, 0);
+  assert.ok(range);
+  const pos = new vscode.Position(2, range.start);
+  editor.selection = new vscode.Selection(pos, pos);
+  return editor;
+}
+
+suite('sort: sortByColumnCommand', () => {
+  suiteTeardown(async () => {
+    await setAlignOnEdit(undefined);
+  });
+
+  test('preserve mode reorders the rows without touching their padding', async () => {
+    await setAlignOnEdit(false);
+    const restore = stubQuickPick('asc');
+    try {
+      const editor = await openTable(UNSORTED);
+      await sortByColumnCommand();
+      assert.strictEqual(
+        editor.document.getText(),
+        ['| Name | Age |', '| --- | --- |', '| Alice | 30 |', '| Bob | 7 |'].join('\n')
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test('descending reverses the rows, still verbatim', async () => {
+    await setAlignOnEdit(false);
+    const restore = stubQuickPick('desc');
+    try {
+      const editor = await openTable(UNSORTED);
+      await sortByColumnCommand();
+      assert.strictEqual(
+        editor.document.getText(),
+        ['| Name | Age |', '| --- | --- |', '| Bob | 7 |', '| Alice | 30 |'].join('\n')
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test('alignOnEdit re-aligns the sorted table', async () => {
+    await setAlignOnEdit(true);
+    const restore = stubQuickPick('asc');
+    try {
+      const editor = await openTable(UNSORTED);
+      await sortByColumnCommand();
+      assert.strictEqual(
+        editor.document.getText(),
+        ['| Name  | Age |', '| ----- | --- |', '| Alice | 30  |', '| Bob   | 7   |'].join('\n')
+      );
+    } finally {
+      restore();
+    }
+  });
+});
 
 suite('sort: sortRowLines', () => {
   test('reorders body lines verbatim, padding included', () => {

--- a/src/test/suite/sort.test.ts
+++ b/src/test/suite/sort.test.ts
@@ -1,0 +1,43 @@
+import * as assert from 'assert';
+import { sortRowLines } from '../../table/commands/sort';
+
+const ROWS = ['| Bob | 7 |', '| Alice | 30 |', '| carol | 8 |'];
+
+suite('sort: sortRowLines', () => {
+  test('reorders body lines verbatim, padding included', () => {
+    assert.deepStrictEqual(sortRowLines(ROWS, 0, false), [
+      '| Alice | 30 |',
+      '| Bob | 7 |',
+      '| carol | 8 |'
+    ]);
+  });
+
+  test('descending reverses the order', () => {
+    assert.deepStrictEqual(sortRowLines(ROWS, 0, true), [
+      '| carol | 8 |',
+      '| Bob | 7 |',
+      '| Alice | 30 |'
+    ]);
+  });
+
+  test('a numeric column sorts numerically, not lexically', () => {
+    assert.deepStrictEqual(sortRowLines(ROWS, 1, false), [
+      '| Bob | 7 |',
+      '| carol | 8 |',
+      '| Alice | 30 |'
+    ]);
+  });
+
+  test('escaped pipes do not shift the compared column', () => {
+    const rows = ['| b \\| x | 2 |', '| a \\| y | 1 |'];
+    assert.deepStrictEqual(sortRowLines(rows, 1, false), [
+      '| a \\| y | 1 |',
+      '| b \\| x | 2 |'
+    ]);
+  });
+
+  test('a ragged row compares as empty and keeps its shape', () => {
+    const rows = ['| b | 2 |', '| a |'];
+    assert.deepStrictEqual(sortRowLines(rows, 1, false), ['| a |', '| b | 2 |']);
+  });
+});

--- a/src/test/suite/sort.test.ts
+++ b/src/test/suite/sort.test.ts
@@ -5,7 +5,7 @@ const ROWS = ['| Bob | 7 |', '| Alice | 30 |', '| carol | 8 |'];
 
 suite('sort: sortRowLines', () => {
   test('reorders body lines verbatim, padding included', () => {
-    assert.deepStrictEqual(sortRowLines(ROWS, 0, false), [
+    assert.deepStrictEqual(sortRowLines(ROWS, 0, false, 2), [
       '| Alice | 30 |',
       '| Bob | 7 |',
       '| carol | 8 |'
@@ -13,7 +13,7 @@ suite('sort: sortRowLines', () => {
   });
 
   test('descending reverses the order', () => {
-    assert.deepStrictEqual(sortRowLines(ROWS, 0, true), [
+    assert.deepStrictEqual(sortRowLines(ROWS, 0, true, 2), [
       '| carol | 8 |',
       '| Bob | 7 |',
       '| Alice | 30 |'
@@ -21,7 +21,7 @@ suite('sort: sortRowLines', () => {
   });
 
   test('a numeric column sorts numerically, not lexically', () => {
-    assert.deepStrictEqual(sortRowLines(ROWS, 1, false), [
+    assert.deepStrictEqual(sortRowLines(ROWS, 1, false, 2), [
       '| Bob | 7 |',
       '| carol | 8 |',
       '| Alice | 30 |'
@@ -30,7 +30,7 @@ suite('sort: sortRowLines', () => {
 
   test('escaped pipes do not shift the compared column', () => {
     const rows = ['| b \\| x | 2 |', '| a \\| y | 1 |'];
-    assert.deepStrictEqual(sortRowLines(rows, 1, false), [
+    assert.deepStrictEqual(sortRowLines(rows, 1, false, 2), [
       '| a \\| y | 1 |',
       '| b \\| x | 2 |'
     ]);
@@ -38,6 +38,11 @@ suite('sort: sortRowLines', () => {
 
   test('a ragged row compares as empty and keeps its shape', () => {
     const rows = ['| b | 2 |', '| a |'];
-    assert.deepStrictEqual(sortRowLines(rows, 1, false), ['| a |', '| b | 2 |']);
+    assert.deepStrictEqual(sortRowLines(rows, 1, false, 2), ['| a |', '| b | 2 |']);
+  });
+
+  test('cells past the header column count do not skew the sort', () => {
+    const rows = ['| b | 2 | z |', '| a | 1 |'];
+    assert.deepStrictEqual(sortRowLines(rows, 2, false, 2), rows);
   });
 });


### PR DESCRIPTION
## Summary

- Table editing commands no longer re-emit the whole aligned table. Insert/Delete/Move Row or Column, Sort Table by Column, and the row added by `Tab`/`Enter` now edit the raw lines, so the padding of every untouched cell survives byte-for-byte.
- New `markdownFoundry.alignOnEdit` (boolean, default `false`) restores the v0.6.0 aligning behavior for anyone who wants it.
- New pure `src/table/cells.ts` — `cellSpans` / `insertCell` / `removeCell` / `swapCells` / `padCells` / `blankRowLike` — operating on raw row text, honoring escaped pipes, indents, ragged rows, and rows without leading/trailing pipes.

## How the two modes stay in sync

Every command does the raw-line edit first; alignment is an optional post-pass that re-parses the edited lines and runs `formatTable`. One implementation per command, so `alignOnEdit: true` reproduces v0.6.0 by construction.

Verified against the v0.6.0 model-splice code offline: 13 table shapes (compact, aligned, indented, escaped pipes, ragged row, ragged separator, over-wide row, header-narrower-than-body, escaped trailing pipe, pipeless `a | b`, header-only, CJK, colon markers) x 13 command variants x every cursor position the caret could occupy on any line x all 3 `defaultAlignment` values = **3573 cases, 0 mismatches**.

## Parity is exact except for three deliberate deviations

Acceptance criterion 3 ("identical to v0.6.0") is knowingly relaxed in exactly three places, each a v0.6.0 bug and each test-pinned:

1. **`Move Column Left` from a cell past the header** (`rowColumn.ts`) — v0.6.0 threw a `TypeError` (`splice` past the end left `undefined` header cells, which `formatTable` cannot render). Now a no-op, like `Move Column Right` already was.
2. **`Delete Column` from a cell past the header** (`rowColumn.ts`) — there is no column there to delete, but v0.6.0 still rewrote the range (dirtying the buffer, pushing an undo step, and silently re-aligning the table as a side effect). Now a no-op.
3. **Caret clamping** (`columnOf`) — the caret is clamped to the table's real columns instead of being left pointing at a phantom one.

Both (1) and (2) are user-visible fixes and are in the CHANGELOG under `### Fixed`. The harness counts them: 27 cases skipped where v0.6.0 throws, 27 intentional deviations.

## Preserve mode, by example

```
| Name | Age |            | Name |  | Age |
| --- | --- |      ->     | --- | :--- | --- |
| Alice | 30 |            | Alice |  | 30 |
| Bob | 7 |               | Bob |  | 7 |
```

The inserted separator marker encodes `markdownFoundry.defaultAlignment` (`left` by default), per the acceptance criteria and v0.6.0 semantics. An inserted row mirrors its neighbor's cell widths using *rendered* width, so its pipes line up even with CJK content, and is never narrower than the header.

## Invariants the primitives hold

Preserve mode has no v0.6.0 baseline to diff against, so the raw-line primitives are pinned by property tests over a 19-shape corpus (piped, pipeless, indented, escaped-pipe, escaped *trailing* pipe, blank outer cells, ragged, single-cell, CJK):

- `cellCount(blankRowLike(line)) === cellCount(line)`
- `cellCount(removeCell(line, i)) === cellCount(line) - 1`, and the result still contains an unescaped pipe
- `cellCount(swapCells(line, a, b)) === cellCount(line)`
- `padCells` always reaches the requested width

The row-likeness half of that matters: a blank cell at either end of a row with no outer pipe is indistinguishable from whitespace, and a row with no pipe left is not a table row — deleting a column from a two-column pipeless table would otherwise turn `Age` over `---` into a **setext heading**.

## Not touched

`align.ts` (Align Table / `alignOnSave`), `convert.ts`, and `insertTable.ts` — they either exist to align, or build a table from scratch where there is no prior formatting to preserve. The `normalizeRowWidth` truncation of over-wide rows is a pre-existing v0.6.0 data-loss bug, filed separately as #137; align mode still reproduces it, preserve mode does not.

## Tests

`npx tsc --noEmit`, `node esbuild.js --production`, and `npm test` all pass — **347 tests**. New `cells.test.ts` (primitives + the property sweeps) and `sort.test.ts` (pure helper + command-level, both modes); new `parser: parseTableFromLines` suite. `rowColumn.test.ts` keeps its existing assertions as the `alignOnEdit: true` regression suite, adds exact-output pins of the v0.6.0 aligned emit, and gains a preserve-mode suite covering escaped pipes, list-indented tables, ragged rows, pipeless tables, CRLF, and cursor placement in both modes.

Closes #135