### PR TITLE
Align Table silently destroys cells past the header on ragged tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ### Fixed
 
+- Aligning a table no longer discards body cells that sit past the last header column. `Align Table`, `markdownFoundry.alignOnSave`, and edits made with `markdownFoundry.alignOnEdit` now widen the table to fit the widest row — the header and separator grow empty, unaligned (`---`) columns instead of the extra cells being silently deleted ([#138](https://github.com/dvlprlife/Markdown-Foundry/pull/138)).
 - `Move Column Left` no longer throws when the cursor sits in a cell past the header's last column (possible when a body row has more cells than the header) — it is now a no-op, like `Move Column Right` already was ([#136](https://github.com/dvlprlife/Markdown-Foundry/pull/136)).
 - `Delete Column` with the cursor in a cell past the header's last column no longer rewrites the table — there is no column there to delete, so it no longer dirties the buffer or pushes an undo step ([#136](https://github.com/dvlprlife/Markdown-Foundry/pull/136)).
 

--- a/src/table/parser.ts
+++ b/src/table/parser.ts
@@ -6,8 +6,10 @@ import { TableLocation } from './locator';
  * Parse the lines of a located table into a TableModel.
  *
  * Contract:
- *   - headers.length === alignments.length
- *   - every row in rows has exactly headers.length cells (padded/truncated as needed)
+ *   - headers.length === alignments.length === the table's column count
+ *   - the column count is the widest of the header, the separator and every
+ *     body row, so no cell is ever dropped
+ *   - every row in rows has exactly headers.length cells (short rows padded)
  *   - cell values are trimmed and have escaped pipes unescaped
  *   - indent is the leading whitespace of the header line
  */
@@ -36,11 +38,19 @@ export function parseTableFromLines(
   const separatorText = lines[1] ?? '';
 
   const indent = leadingIndent(headerText);
-  const headers = splitRow(headerText);
-  const alignments = parseAlignments(separatorText, headers.length);
-  const rows = lines
-    .slice(2)
-    .map((line) => normalizeRowWidth(splitRow(line), headers.length));
+  const headerCells = splitRow(headerText);
+  const bodyCells = lines.slice(2).map(splitRow);
+
+  // Widening to the widest row rather than the header's width is what keeps a
+  // body cell past the last header column from being deleted on re-emit.
+  const columns = bodyCells.reduce(
+    (widest, row) => Math.max(widest, row.length),
+    Math.max(headerCells.length, splitRow(separatorText).length)
+  );
+
+  const headers = normalizeRowWidth(headerCells, columns);
+  const alignments = parseAlignments(separatorText, columns);
+  const rows = bodyCells.map((row) => normalizeRowWidth(row, columns));
 
   return { headers, alignments, rows, range, indent, eol };
 }

--- a/src/test/suite/align.test.ts
+++ b/src/test/suite/align.test.ts
@@ -1,0 +1,162 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { alignTableCommand, alignAllTablesInDocument } from '../../table/commands/align';
+
+/** A body row wider than the header: `c` and `d` sit past the last column. */
+const HEADER_NARROW = ['| A | B |', '| --- | --- |', '| a | b | c | d |'];
+
+async function openTable(lines: string[]): Promise<vscode.TextEditor> {
+  const doc = await vscode.workspace.openTextDocument({
+    language: 'markdown',
+    content: lines.join('\n')
+  });
+  return vscode.window.showTextDocument(doc);
+}
+
+function putCursor(editor: vscode.TextEditor, line: number): void {
+  const pos = new vscode.Position(line, 0);
+  editor.selection = new vscode.Selection(pos, pos);
+}
+
+async function applyEdits(editor: vscode.TextEditor, edits: vscode.TextEdit[]): Promise<void> {
+  await editor.edit((builder) => {
+    for (const edit of edits) {
+      builder.replace(edit.range, edit.newText);
+    }
+  });
+}
+
+suite('align: Align Table keeps cells past the header', () => {
+  test('widens the table instead of dropping the over-wide cells', async () => {
+    const editor = await openTable(HEADER_NARROW);
+    putCursor(editor, 2);
+    await alignTableCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      ['| A   | B   |     |     |', '| --- | --- | --- | --- |', '| a   | b   | c   | d   |'].join(
+        '\n'
+      )
+    );
+  });
+
+  test('recovered columns are unaligned; the authored markers survive', async () => {
+    const editor = await openTable(['| A | B |', '| :--- | ---: |', '| a | b | c |']);
+    putCursor(editor, 0);
+    await alignTableCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      ['| A   |   B |     |', '| :-- | --: | --- |', '| a   |   b | c   |'].join('\n')
+    );
+  });
+
+  test('pads a short row while widening for an over-wide one', async () => {
+    const editor = await openTable([
+      '| A | B | C |',
+      '| --- | --- | --- |',
+      '| a1 |',
+      '| a2 | b2 | c2 | d2 |'
+    ]);
+    putCursor(editor, 2);
+    await alignTableCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      [
+        '| A   | B   | C   |     |',
+        '| --- | --- | --- | --- |',
+        '| a1  |     |     |     |',
+        '| a2  | b2  | c2  | d2  |'
+      ].join('\n')
+    );
+  });
+
+  test('a pipeless over-wide row keeps its cells', async () => {
+    const editor = await openTable(['a | b', '--- | ---', 'a1 | b1 | c1']);
+    putCursor(editor, 2);
+    await alignTableCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      ['| a   | b   |     |', '| --- | --- | --- |', '| a1  | b1  | c1  |'].join('\n')
+    );
+  });
+
+  test('an escaped pipe in a recovered cell stays escaped', async () => {
+    const editor = await openTable(['| A | B |', '| --- | --- |', '| a | b | c \\| d |']);
+    putCursor(editor, 2);
+    await alignTableCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      ['| A   | B   |        |', '| --- | --- | ------ |', '| a   | b   | c \\| d |'].join('\n')
+    );
+  });
+
+  test('an indented over-wide table keeps its indent', async () => {
+    const editor = await openTable(['- item', '  | A | B |', '  | --- | --- |', '  | a | b | c |']);
+    putCursor(editor, 3);
+    await alignTableCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      [
+        '- item',
+        '  | A   | B   |     |',
+        '  | --- | --- | --- |',
+        '  | a   | b   | c   |'
+      ].join('\n')
+    );
+  });
+
+  test('a CRLF document keeps its line endings and its cells', async () => {
+    const editor = await openTable(HEADER_NARROW);
+    await editor.edit((edit) => edit.setEndOfLine(vscode.EndOfLine.CRLF));
+    putCursor(editor, 2);
+    await alignTableCommand();
+    assert.strictEqual(
+      editor.document.getText(),
+      ['| A   | B   |     |     |', '| --- | --- | --- | --- |', '| a   | b   | c   | d   |'].join(
+        '\r\n'
+      )
+    );
+  });
+
+  test('aligning twice is a no-op', async () => {
+    const editor = await openTable(HEADER_NARROW);
+    putCursor(editor, 2);
+    await alignTableCommand();
+    const once = editor.document.getText();
+    await alignTableCommand();
+    assert.strictEqual(editor.document.getText(), once);
+  });
+});
+
+// alignOnSave runs this over the whole document from onWillSaveTextDocument.
+suite('align: alignAllTablesInDocument keeps cells past the header', () => {
+  test('every table is widened, none is truncated', async () => {
+    const editor = await openTable([
+      '# Doc',
+      '',
+      ...HEADER_NARROW,
+      '',
+      'text',
+      '',
+      '| X | Y |',
+      '| --- | --- |',
+      '| x1 | y1 | z1 |'
+    ]);
+    await applyEdits(editor, alignAllTablesInDocument(editor.document));
+    assert.strictEqual(
+      editor.document.getText(),
+      [
+        '# Doc',
+        '',
+        '| A   | B   |     |     |',
+        '| --- | --- | --- | --- |',
+        '| a   | b   | c   | d   |',
+        '',
+        'text',
+        '',
+        '| X   | Y   |     |',
+        '| --- | --- | --- |',
+        '| x1  | y1  | z1  |'
+      ].join('\n')
+    );
+  });
+});

--- a/src/test/suite/formatter.test.ts
+++ b/src/test/suite/formatter.test.ts
@@ -44,6 +44,20 @@ suite('formatter: formatTable', () => {
     assert.ok(/-+:/.test(separator), 'right marker present');
   });
 
+  test('emits a column for every cell of a widened model', () => {
+    const model = makeModel({
+      headers: ['A', 'B', '', ''],
+      alignments: ['left', 'right', 'none', 'none'],
+      rows: [['a', 'b', 'c', 'd']]
+    });
+    assert.strictEqual(
+      formatTable(model),
+      ['| A   |   B |     |     |', '| :-- | --: | --- | --- |', '| a   |   b | c   | d   |'].join(
+        '\n'
+      )
+    );
+  });
+
   test('escapes pipes inside cells', () => {
     const model = makeModel({
       headers: ['a'],

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { splitRow, parseAlignments, parseTableFromLines } from '../../table/parser';
+import { formatTable } from '../../table/formatter';
 
 const RANGE = new vscode.Range(0, 0, 0, 0);
 
@@ -21,15 +22,17 @@ suite('parser: parseTableFromLines', () => {
     assert.strictEqual(model.eol, '\n');
   });
 
-  test('pads a ragged row and truncates an over-wide one to the header width', () => {
+  test('pads a short row and widens the table to fit an over-wide one', () => {
     const model = parseTableFromLines(
       ['| A | B |', '| --- | --- |', '| a1 |', '| a2 | b2 | c2 |'],
       RANGE,
       '\n'
     );
+    assert.deepStrictEqual(model.headers, ['A', 'B', '']);
+    assert.deepStrictEqual(model.alignments, ['none', 'none', 'none']);
     assert.deepStrictEqual(model.rows, [
-      ['a1', ''],
-      ['a2', 'b2']
+      ['a1', '', ''],
+      ['a2', 'b2', 'c2']
     ]);
   });
 
@@ -62,6 +65,153 @@ suite('parser: parseTableFromLines', () => {
     assert.deepStrictEqual(model.rows, []);
     assert.deepStrictEqual(model.headers, ['A', 'B']);
   });
+});
+
+suite('parser: widening to the widest row', () => {
+  test('a body row past the last header column keeps every cell', () => {
+    const model = parseTableFromLines(
+      ['| A | B |', '| --- | --- |', '| a | b | c | d |'],
+      RANGE,
+      '\n'
+    );
+    assert.strictEqual(model.headers.length, 4);
+    assert.deepStrictEqual(model.headers, ['A', 'B', '', '']);
+    assert.deepStrictEqual(model.alignments, ['none', 'none', 'none', 'none']);
+    assert.deepStrictEqual(model.rows, [['a', 'b', 'c', 'd']]);
+  });
+
+  test('a separator wider than the header widens the table', () => {
+    const model = parseTableFromLines(
+      ['| A | B |', '| --- | --- | --- |', '| a | b |'],
+      RANGE,
+      '\n'
+    );
+    assert.deepStrictEqual(model.headers, ['A', 'B', '']);
+    assert.deepStrictEqual(model.rows, [['a', 'b', '']]);
+  });
+
+  test('recovered columns are unaligned; the authored markers survive', () => {
+    const model = parseTableFromLines(
+      ['| A | B |', '| :--- | ---: |', '| a | b | c |'],
+      RANGE,
+      '\n'
+    );
+    assert.deepStrictEqual(model.alignments, ['left', 'right', 'none']);
+  });
+
+  test('a pipeless over-wide row keeps every cell', () => {
+    const model = parseTableFromLines(['a | b', '--- | ---', 'a1 | b1 | c1'], RANGE, '\n');
+    assert.deepStrictEqual(model.headers, ['a', 'b', '']);
+    assert.deepStrictEqual(model.rows, [['a1', 'b1', 'c1']]);
+  });
+
+  test('an over-wide row with no trailing pipe keeps every cell', () => {
+    const model = parseTableFromLines(['| A | B |', '| --- | --- |', '| a | b | c'], RANGE, '\n');
+    assert.deepStrictEqual(model.rows, [['a', 'b', 'c']]);
+  });
+
+  test('an over-wide row ending in an escaped pipe keeps every cell', () => {
+    const model = parseTableFromLines(
+      ['| A | B |', '| --- | --- |', '| a | b | c \\|'],
+      RANGE,
+      '\n'
+    );
+    assert.deepStrictEqual(model.rows, [['a', 'b', 'c |']]);
+  });
+
+  test('an escaped pipe inside a recovered cell is content, not a separator', () => {
+    const model = parseTableFromLines(
+      ['| A | B |', '| --- | --- |', '| a | b | c \\| d |'],
+      RANGE,
+      '\n'
+    );
+    assert.strictEqual(model.headers.length, 3);
+    assert.deepStrictEqual(model.rows, [['a', 'b', 'c | d']]);
+  });
+
+  test('an indented over-wide table keeps its indent and its cells', () => {
+    const model = parseTableFromLines(
+      ['  | A | B |', '  | --- | --- |', '  | a | b | c |'],
+      RANGE,
+      '\n'
+    );
+    assert.strictEqual(model.indent, '  ');
+    assert.deepStrictEqual(model.rows, [['a', 'b', 'c']]);
+  });
+
+  test('a table with both an over-wide row and a short row pads only the short one', () => {
+    const model = parseTableFromLines(
+      ['| A | B | C |', '| --- | --- | --- |', '| a1 |', '| a2 | b2 | c2 | d2 |'],
+      RANGE,
+      '\n'
+    );
+    assert.deepStrictEqual(model.headers, ['A', 'B', 'C', '']);
+    assert.deepStrictEqual(model.rows, [
+      ['a1', '', '', ''],
+      ['a2', 'b2', 'c2', 'd2']
+    ]);
+  });
+});
+
+/** Edge-shaped tables: pipeless, unterminated, escaped pipes, indented, CRLF. */
+const EDGE_SHAPES: Array<{ name: string; lines: string[]; eol: string }> = [
+  { name: 'body wider than header', lines: ['| A | B |', '| --- | --- |', '| a | b | c | d |'], eol: '\n' },
+  { name: 'separator wider than header', lines: ['| A | B |', '| --- | --- | --- |', '| a | b |'], eol: '\n' },
+  {
+    name: 'over-wide and short rows together',
+    lines: ['| A | B | C |', '| --- | --- | --- |', '| a1 |', '| a2 | b2 | c2 | d2 |'],
+    eol: '\n'
+  },
+  { name: 'pipeless', lines: ['a | b', '--- | ---', 'a1 | b1 | c1'], eol: '\n' },
+  { name: 'no trailing pipe', lines: ['| A | B |', '| --- | --- |', '| a | b | c'], eol: '\n' },
+  { name: 'trailing escaped pipe', lines: ['| A | B |', '| --- | --- |', '| a | b | c \\|'], eol: '\n' },
+  {
+    name: 'escaped pipe in a recovered cell',
+    lines: ['| A | B |', '| --- | --- |', '| a | b | c \\| d |'],
+    eol: '\n'
+  },
+  { name: 'indented', lines: ['  | A | B |', '  | --- | --- |', '  | a | b | c |'], eol: '\n' },
+  { name: 'aligned markers', lines: ['| A | B |', '| :--- | ---: |', '| a | b | c |'], eol: '\n' },
+  { name: 'CRLF', lines: ['| A | B |', '| --- | --- |', '| a | b | c |'], eol: '\r\n' },
+  { name: 'CJK', lines: ['| 名前 |', '| --- |', '| 太郎 | 30 |'], eol: '\n' }
+];
+
+suite('parser: parse → format is lossless', () => {
+  for (const { name, lines, eol } of EDGE_SHAPES) {
+    test(`no cell is dropped: ${name}`, () => {
+      const model = parseTableFromLines(lines, RANGE, eol);
+      const columns = model.headers.length;
+
+      assert.strictEqual(model.alignments.length, columns, 'one alignment per column');
+      for (const row of model.rows) {
+        assert.strictEqual(row.length, columns, 'every row is the table width');
+      }
+
+      // Every cell the author wrote is still in the model, in its own column.
+      const authored = [lines[0], ...lines.slice(2)].map(splitRow);
+      const modeled = [model.headers, ...model.rows];
+      for (let i = 0; i < authored.length; i++) {
+        assert.deepStrictEqual(
+          modeled[i].slice(0, authored[i].length),
+          authored[i],
+          `row ${i} lost a cell`
+        );
+      }
+
+      // Re-emitting and re-parsing yields the same model: format drops nothing
+      // the parser recovered, and aligning twice changes nothing.
+      const once = formatTable(model);
+      const reparsed = parseTableFromLines(once.split(eol), RANGE, eol);
+      assert.deepStrictEqual(reparsed.headers, model.headers, 'headers survive a round-trip');
+      assert.deepStrictEqual(reparsed.rows, model.rows, 'rows survive a round-trip');
+      assert.deepStrictEqual(
+        reparsed.alignments,
+        model.alignments,
+        'alignments survive a round-trip'
+      );
+      assert.strictEqual(formatTable(reparsed), once, 'aligning is idempotent');
+    });
+  }
 });
 
 suite('parser: splitRow', () => {

--- a/src/test/suite/rowColumn.test.ts
+++ b/src/test/suite/rowColumn.test.ts
@@ -282,20 +282,29 @@ suite('rowColumn (alignOnEdit): re-aligns the whole table', () => {
   });
 
   // The cursor's column is counted on its own line, so a body row wider than
-  // the header reports a column past the header's last. v0.6.0 clamped it via
-  // Array.splice; the new column must not run off the end of the table.
-  test('insert column right from a cell past the header clamps to the last column', async () => {
+  // the header reports a column past the header's last. The new column is
+  // clamped to the header's width, and the align pass now grows the table to
+  // fit the over-wide cells rather than dropping them.
+  test('insert column right from a cell past the header clamps the new column and keeps c and d', async () => {
     const editor = await openTable(HEADER_NARROW.join('\n'));
     placeCursorInCell(editor, 2, 3); // the body row's 4th cell — the header has 2
     await insertColumnRightCommand();
-    assertLines(editor, ['| A   | B   |     |', '| --- | --- | :-- |', '| a   | b   |     |']);
+    assertLines(editor, [
+      '| A   | B   |     |     |     |',
+      '| --- | --- | :-- | --- | --- |',
+      '| a   | b   |     | c   | d   |'
+    ]);
   });
 
-  test('insert column left from a cell past the header clamps to the last column', async () => {
+  test('insert column left from a cell past the header clamps the new column and keeps c and d', async () => {
     const editor = await openTable(HEADER_NARROW.join('\n'));
     placeCursorInCell(editor, 2, 2); // the body row's 3rd cell — the header has 2
     await insertColumnLeftCommand();
-    assertLines(editor, ['| A   | B   |     |', '| --- | --- | :-- |', '| a   | b   |     |']);
+    assertLines(editor, [
+      '| A   | B   |     |     |     |',
+      '| --- | --- | :-- | --- | --- |',
+      '| a   | b   |     | c   | d   |'
+    ]);
   });
 
   // There is no column there to delete, so the command must not touch the
@@ -525,6 +534,23 @@ suite('rowColumn (preserve): edits leave untouched cells byte-for-byte', () => {
     placeCursorInCell(editor, 2, 3);
     await insertColumnRightCommand();
     assertLines(editor, ['| A | B |  |', '| --- | --- | :--- |', '| a | b |  | c | d |']);
+  });
+
+  // Align mode grows the table to fit an over-wide row. Preserve mode never
+  // round-trips through the model, so it must not reflow the table at all.
+  test('an over-wide row is left byte-for-byte by an edit elsewhere in the table', async () => {
+    const editor = await openTable(
+      ['| A | B |', '| --- | --- |', '| a1 | b1 |', '| a2 | b2 | c2 | d2 |'].join('\n')
+    );
+    placeCursorInCell(editor, 2, 0);
+    await insertRowBelowCommand();
+    assertLines(editor, [
+      '| A | B |',
+      '| --- | --- |',
+      '| a1 | b1 |',
+      '|    |    |',
+      '| a2 | b2 | c2 | d2 |'
+    ]);
   });
 
   test('a CRLF document keeps its line endings', async () => {


### PR DESCRIPTION
## Summary

- `parseTableFromLines` took the table's column count from the header, so `normalizeRowWidth` truncated every longer body row — `Align Table`, `markdownFoundry.alignOnSave`, and any command run with `alignOnEdit: true` permanently deleted body cells past the last header column. The column count is now the **maximum** across the header, the separator, and all body rows, so the table grows to fit the widest row instead of dropping cells.
- Recovered columns get an empty header cell and alignment `none` (a plain `---`), not `defaultAlignment`: `parser.ts` stays pure (no config read), and a recovered column is not an inserted one.
- The formatter needed no change — `computeColumnWidths` / `formatRow` / `formatSeparator` all key off `headers.length`, so a widened model emits every column for free. Short rows are still padded with empty cells.

## Behavior

```
| A | B |            | A   | B   |     |     |
| --- | --- |   ->   | --- | --- | --- | --- |
| a | b | c | d |    | a   | b   | c   | d   |
```

Previously `c` and `d` were deleted.

## Tests

- `parser.test.ts` — a widening suite (body wider than header, separator wider than header, both an over-wide *and* a short row, pipeless, no trailing pipe, row ending in an escaped pipe, escaped pipe inside a recovered cell, indented, authored alignment markers preserved), plus an invariant suite over 11 edge-shaped tables asserting one alignment per column, uniform row width, that every authored cell survives into its own column, and that parse → format → parse is lossless and idempotent.
- `formatter.test.ts` — a widened model emits every column, with `---` (not `:---`) for the recovered ones.
- `align.test.ts` (new) — command-level pins for `Align Table` (lossless on the issue's fixture, escaped pipes, pipeless, indented, CRLF, idempotent) and for `alignAllTablesInDocument`, the `alignOnSave` path.
- `rowColumn.test.ts` — the two `alignOnEdit: true` fixtures added in #136 to pin the truncating behavior ("insert column right/left from a cell past the header") are **updated, not deleted**: the new column is still clamped to the header's width, but `c` and `d` now survive. This is the intentional break of #136's byte-for-byte v0.6.0 parity, on ragged tables only.
- Preserve mode (`alignOnEdit: false`, the default) never round-trips through the model and is unaffected — pinned by a new test that an over-wide row is left byte-for-byte by an edit elsewhere in the table.
- Re-ran #136's offline parse → format parity harness over 13 fixtures: 4 well-formed tables keep byte-for-byte v0.6.0 parity, 9 ragged ones deviate as intended, 0 lossy, 0 non-idempotent.

No README change: no new command, setting, or keybinding.

Closes #137