### PR TITLE
release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Markdown Foundry extension will be documented in this
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-14
+
 ### Added
 
 - `markdownFoundry.alignOnEdit` (default `false`) — set it to `true` to restore the previous behavior of re-aligning the whole table after every table editing command ([#136](https://github.com/dvlprlife/Markdown-Foundry/pull/136)).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdfoundry",
   "displayName": "Markdown Foundry",
   "description": "Powerful Markdown table editing and authoring tools — align, navigate, insert, and transform tables with ease.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publisher": "dvlprlife",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

- Roll `[Unreleased]` into `[0.7.0] - 2026-07-14` and add a fresh empty `[Unreleased]` section
- Bump `package.json` version 0.6.0 → 0.7.0

Ships the table-editing overhaul: editing commands no longer re-align the whole table (new `markdownFoundry.alignOnEdit` setting, default `false`), plus three fixes to pre-existing bugs on ragged tables — `Align Table` silently destroying cells past the header, a `Move Column Left` crash, and a `Delete Column` no-op that dirtied the buffer.

Release housekeeping only — no issue, matching the v0.6.0 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
